### PR TITLE
Updating GRPC libraries and `netstandard`

### DIFF
--- a/Spice/Spice.csproj
+++ b/Spice/Spice.csproj
@@ -8,13 +8,14 @@
         <Description>SpiceAI Dotnet SDK</Description>
         <Authors>SpiceAI OSS</Authors>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Apache.Arrow" Version="16.1.0"/>
-        <PackageReference Include="Apache.Arrow.Flight" Version="16.1.0"/>
-        <PackageReference Include="Polly" Version="8.4.0"/>
+        <PackageReference Include="Apache.Arrow" Version="16.1.0" />
+        <PackageReference Include="Apache.Arrow.Flight" Version="16.1.0" />
+        <PackageReference Include="Grpc.Net.Client.Web" Version="2.66.0" />
+        <PackageReference Include="Polly" Version="8.4.0" />
 
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>SpiceTest</_Parameter1>

--- a/Spice/Spice.csproj
+++ b/Spice/Spice.csproj
@@ -16,7 +16,6 @@
         <PackageReference Include="Apache.Arrow.Flight" Version="16.1.0" />
         <PackageReference Include="Grpc.Core.Api" Version="2.66.0" />
         <PackageReference Include="Grpc.Net.Client" Version="2.66.0" />
-        <!--<PackageReference Include="Grpc.Net.Client.Web" Version="2.66.0" />-->
         <PackageReference Include="Grpc.Net.Common" Version="2.66.0" />
         <PackageReference Include="Polly" Version="8.4.0" />
 

--- a/Spice/Spice.csproj
+++ b/Spice/Spice.csproj
@@ -8,7 +8,7 @@
         <Description>SpiceAI Dotnet SDK</Description>
         <Authors>SpiceAI OSS</Authors>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Spice/Spice.csproj
+++ b/Spice/Spice.csproj
@@ -8,7 +8,7 @@
         <Description>SpiceAI Dotnet SDK</Description>
         <Authors>SpiceAI OSS</Authors>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Spice/Spice.csproj
+++ b/Spice/Spice.csproj
@@ -14,7 +14,10 @@
     <ItemGroup>
         <PackageReference Include="Apache.Arrow" Version="16.1.0" />
         <PackageReference Include="Apache.Arrow.Flight" Version="16.1.0" />
-        <PackageReference Include="Grpc.Net.Client.Web" Version="2.66.0" />
+        <PackageReference Include="Grpc.Core.Api" Version="2.66.0" />
+        <PackageReference Include="Grpc.Net.Client" Version="2.66.0" />
+        <!--<PackageReference Include="Grpc.Net.Client.Web" Version="2.66.0" />-->
+        <PackageReference Include="Grpc.Net.Common" Version="2.66.0" />
         <PackageReference Include="Polly" Version="8.4.0" />
 
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Spice/src/Flight/SpiceFlightClient.cs
+++ b/Spice/src/Flight/SpiceFlightClient.cs
@@ -25,7 +25,6 @@ using Apache.Arrow.Flight;
 using Apache.Arrow.Flight.Client;
 using Grpc.Core;
 using Grpc.Net.Client;
-using Grpc.Net.Client.Web;
 using Polly;
 using Polly.Retry;
 using Spice.Auth;

--- a/Spice/src/Flight/SpiceFlightClient.cs
+++ b/Spice/src/Flight/SpiceFlightClient.cs
@@ -54,8 +54,7 @@ internal class SpiceFlightClient
                 Authorization = AuthHeaderBuilder.BasicAuth(appId, apiKey)
             }
         };
-        options.HttpHandler = new GrpcWebHandler(new HttpClientHandler());
-
+        
         options.HttpClient.DefaultRequestHeaders.Add("X-Spice-User-Agent", UserAgent.agent());
 
         return options;

--- a/Spice/src/Flight/SpiceFlightClient.cs
+++ b/Spice/src/Flight/SpiceFlightClient.cs
@@ -25,6 +25,7 @@ using Apache.Arrow.Flight;
 using Apache.Arrow.Flight.Client;
 using Grpc.Core;
 using Grpc.Net.Client;
+using Grpc.Net.Client.Web;
 using Polly;
 using Polly.Retry;
 using Spice.Auth;
@@ -51,9 +52,9 @@ internal class SpiceFlightClient
             DefaultRequestHeaders =
             {
                 Authorization = AuthHeaderBuilder.BasicAuth(appId, apiKey)
-
             }
         };
+        options.HttpHandler = new GrpcWebHandler(new HttpClientHandler());
 
         options.HttpClient.DefaultRequestHeaders.Add("X-Spice-User-Agent", UserAgent.agent());
 


### PR DESCRIPTION
## 🗣 Description

This fixes the Windows test runner by upgrading the GRPC libraries and `netstandard` version. GRPC is now `2.66.0` and `netstandard` is now `2.1`.

## 🔨 Related Issues

- Fixes test runner on Windows (discovered by @peasee in change #9 )

## 🤔 Concerns
