### PR TITLE
Adding custom User-Agent to .NET client

### DIFF
--- a/Spice/src/Config/SpiceUserAgent.cs
+++ b/Spice/src/Config/SpiceUserAgent.cs
@@ -22,7 +22,7 @@ SOFTWARE.
 
 namespace Spice.Config;
 
-internal static class UserAgent
+public static class SpiceUserAgent
 {
     public static string agent(string? client = null, string? clientVersion = null, string? clientSystem = null, string? clientExtension = null)
     {

--- a/Spice/src/Config/UserAgent.cs
+++ b/Spice/src/Config/UserAgent.cs
@@ -24,7 +24,7 @@ namespace Spice.Config;
 
 internal static class UserAgent
 {
-    public static string agent()
+    public static string agent(client:string = null, clientVersion:string = null, clientSystem:string = null, clientExtension:string = null)
     {
         // get OS type, release and machine type (x86, x64, arm, etc)
         var os = Environment.OSVersion;
@@ -60,7 +60,11 @@ internal static class UserAgent
         // get the runtime version
         var appVersion = typeof(SpiceClient).Assembly.GetName().Version;
 
+        var clientName = client ?? "spice-dotnet";
+        var clientVer = clientVersion ?? appVersion.ToString();
+        var clientSys = clientSystem ?? $"{osTypeStr}/{osVersion} {osArchStr}";
+        var clientExt = $" {clientExtension}" ?? "";
         // return the user agent string
-        return $"spice-dotnet {appVersion} ({osTypeStr}/{osVersion} {osArchStr})";
+        return $"spice-dotnet/{clientVer} ({clientSys}){clientExt}";
     }
 }

--- a/Spice/src/Config/UserAgent.cs
+++ b/Spice/src/Config/UserAgent.cs
@@ -24,7 +24,7 @@ namespace Spice.Config;
 
 internal static class UserAgent
 {
-    public static string agent(client:string = null, clientVersion:string = null, clientSystem:string = null, clientExtension:string = null)
+    public static string agent(string? client = null, string? clientVersion = null, string? clientSystem = null, string? clientExtension = null)
     {
         // get OS type, release and machine type (x86, x64, arm, etc)
         var os = Environment.OSVersion;
@@ -61,7 +61,7 @@ internal static class UserAgent
         var appVersion = typeof(SpiceClient).Assembly.GetName().Version;
 
         var clientName = client ?? "spice-dotnet";
-        var clientVer = clientVersion ?? appVersion.ToString();
+        var clientVer = clientVersion ?? appVersion?.ToString();
         var clientSys = clientSystem ?? $"{osTypeStr}/{osVersion} {osArchStr}";
         var clientExt = $" {clientExtension}" ?? "";
         // return the user agent string

--- a/Spice/src/Flight/SpiceFlightClient.cs
+++ b/Spice/src/Flight/SpiceFlightClient.cs
@@ -65,7 +65,7 @@ internal class SpiceFlightClient
         return responseHeaders.Get("authorization") ?? trailers.Get("authorization");
     }
 
-    internal SpiceFlightClient(string address, int maxRetries, string? appId, string? apiKey)
+    internal SpiceFlightClient(string address, int maxRetries, string? appId, string? apiKey, string? userAgent)
     {
         _retryPolicy = Policy.Handle<RpcException>(ex =>
                 ex.Status.StatusCode is StatusCode.Unavailable or StatusCode.DeadlineExceeded or StatusCode.Aborted
@@ -78,7 +78,7 @@ internal class SpiceFlightClient
                         $"Request failed. Waiting {timespan} before next retry. Retry attempt {retryAttempt}");
                 });
 
-        var options = GetGrpcChannelOptions(appId, apiKey);
+        var options = GetGrpcChannelOptions(appId, apiKey, userAgent);
 
         _flightClient = new FlightClient(GrpcChannel.ForAddress(address, options));
 

--- a/Spice/src/Flight/SpiceFlightClient.cs
+++ b/Spice/src/Flight/SpiceFlightClient.cs
@@ -38,7 +38,7 @@ internal class SpiceFlightClient
     private readonly FlightClient _flightClient;
     private readonly AsyncRetryPolicy _retryPolicy;
 
-    private static GrpcChannelOptions GetGrpcChannelOptions(string? appId, string? apiKey)
+    private static GrpcChannelOptions GetGrpcChannelOptions(string? appId, string? apiKey, string? userAgent)
     {
         var options = new GrpcChannelOptions();
 
@@ -54,7 +54,8 @@ internal class SpiceFlightClient
             }
         };
         
-        options.HttpClient.DefaultRequestHeaders.Add("X-Spice-User-Agent", UserAgent.agent());
+        var uaString = userAgent ?? UserAgent.agent();
+        options.HttpClient.DefaultRequestHeaders.Add("User-Agent", uaString);
 
         return options;
     }

--- a/Spice/src/Flight/SpiceFlightClient.cs
+++ b/Spice/src/Flight/SpiceFlightClient.cs
@@ -54,7 +54,7 @@ internal class SpiceFlightClient
             }
         };
         
-        var uaString = userAgent ?? UserAgent.agent();
+        var uaString = userAgent ?? SpiceUserAgent.agent();
         options.HttpClient.DefaultRequestHeaders.Add("User-Agent", uaString);
 
         return options;

--- a/Spice/src/SpiceClient.cs
+++ b/Spice/src/SpiceClient.cs
@@ -39,6 +39,11 @@ public class SpiceClient
     public string? ApiKey { get; internal set; }
 
     /// <summary>
+    /// Gets or sets the User-Agent string. This property is internal set and can be null.
+    /// </summary>
+    public string? UserAgent { get; internal set; }
+
+    /// <summary>
     /// Gets or sets the flight address. This property is internal set and defaults to local flight endpoint.
     /// </summary>
     public string FlightAddress { get; internal set; } = SpiceDefaultConfigLocal.FlightAddress;
@@ -53,7 +58,7 @@ public class SpiceClient
 
     internal void Init()
     {
-        FlightClient = new SpiceFlightClient(FlightAddress, MaxRetries, AppId, ApiKey);
+        FlightClient = new SpiceFlightClient(FlightAddress, MaxRetries, AppId, ApiKey, UserAgent);
     }
 
     /// <summary>

--- a/Spice/src/SpiceClientBuilder.cs
+++ b/Spice/src/SpiceClientBuilder.cs
@@ -81,6 +81,17 @@ public class SpiceClientBuilder
     }
 
     /// <summary>
+    /// Sets the client's user agent.
+    /// </summary>
+    /// <param name="userAgent">User agent string</param>
+    /// <returns>The current instance of <see cref="SpiceClientBuilder"/> for method chaining.</returns>
+    public SpiceClientBuilder WithUserAgent(string userAgent)
+    {
+        _spiceClient.UserAgent = userAgent;
+        return this;
+    }
+
+    /// <summary>
     /// Initiates <see cref="SpiceClient" /> with provided parameters.
     /// </summary>
     /// <returns>The current instance of <see cref="SpiceClient"/> for method chaining.</returns>

--- a/SpiceTest/UserAgentTest.cs
+++ b/SpiceTest/UserAgentTest.cs
@@ -32,7 +32,7 @@ public class UserAgentTest
     {
         await Task.Run(() =>
         {
-            var agent = UserAgent.agent();
+            var agent = SpiceUserAgent.agent();
 
             // test with a regex
             Assert.IsTrue(Regex.IsMatch(agent, @"spice-dotnet/\d+\.\d+\.\d+\.\d+ \((Unix|Windows|Darwin)/[\d\w\.\-_]+ (x86_64|aarch64|i386)\)"), agent);

--- a/SpiceTest/UserAgentTest.cs
+++ b/SpiceTest/UserAgentTest.cs
@@ -35,7 +35,7 @@ public class UserAgentTest
             var agent = UserAgent.agent();
 
             // test with a regex
-            Assert.IsTrue(Regex.IsMatch(agent, @"spice-dotnet \d+\.\d+\.\d+\.\d+ \((Unix|Windows|Darwin)/[\d\w\.\-_]+ (x86_64|aarch64|i386)\)"), agent);
+            Assert.IsTrue(Regex.IsMatch(agent, @"spice-dotnet/\d+\.\d+\.\d+\.\d+ \((Unix|Windows|Darwin)/[\d\w\.\-_]+ (x86_64|aarch64|i386)\)"), agent);
         });
     }
 }


### PR DESCRIPTION
## 🗣 Description

* Adding a custom user-agent to spice-dotnet to improve the identification of the client when making requests.
* Changing header from `x-spice-user-agent` to standard `User-Agent`

## 🔨 Related Issues

## 🤔 Concerns
