### PR TITLE
fix: Set PooledConnectionLifetime for DNS re-resolution on long-lived connections

### DIFF
--- a/Spice/src/Flight/SpiceFlightClient.cs
+++ b/Spice/src/Flight/SpiceFlightClient.cs
@@ -56,7 +56,12 @@ internal class SpiceFlightClient : IDisposable
                 // Configure HttpHandler for TLS on macOS (.NET 8.0+)
                 var handler = new SocketsHttpHandler
                 {
-                    EnableMultipleHttp2Connections = true
+                    EnableMultipleHttp2Connections = true,
+                    // Force periodic connection recycling to trigger DNS re-resolution.
+                    // Without this, HTTP/2 connections are kept alive indefinitely and
+                    // the client can get stuck on stale IPs when backend targets change
+                    // (e.g. AWS ALB target rotation).
+                    PooledConnectionLifetime = TimeSpan.FromMinutes(5),
                 };
                 options.HttpHandler = handler;
             }
@@ -74,7 +79,12 @@ internal class SpiceFlightClient : IDisposable
         {
             messageHandler = new SocketsHttpHandler
             {
-                EnableMultipleHttp2Connections = true
+                EnableMultipleHttp2Connections = true,
+                // Force periodic connection recycling to trigger DNS re-resolution.
+                // Without this, HTTP/2 connections are kept alive indefinitely and
+                // the client can get stuck on stale IPs when backend targets change
+                // (e.g. AWS ALB target rotation).
+                PooledConnectionLifetime = TimeSpan.FromMinutes(5),
             };
         }
         else


### PR DESCRIPTION
## Problem

`GrpcChannel.ForAddress` creates long-lived HTTP/2 connections via `SocketsHttpHandler`. By default, `PooledConnectionLifetime` is infinite — connections are never recycled and DNS is never re-resolved.

For clients connecting to load-balanced endpoints (e.g. AWS ALBs), backend IPs can change while the HTTP/2 connection remains healthy, leaving the client stuck on a stale IP.

## Fix

Set `PooledConnectionLifetime = TimeSpan.FromMinutes(5)` on both `SocketsHttpHandler` instances (unauthenticated and authenticated TLS paths). This forces periodic connection recycling, which triggers fresh DNS resolution.

This is the [recommended .NET approach](https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines#dns-behavior) for handling DNS changes with long-lived `HttpClient` / gRPC connections.

## Related

- spiceai/spice-java#39 — equivalent fix for the Java SDK (uses gRPC DnsNameResolver for periodic re-resolution)
- spiceai/spice-rs#71 — equivalent fix for the Rust SDK (HTTP/2 keep-alive for stale connection detection)