### PR TITLE
feat: add mTLS client certificate support

### DIFF
--- a/Spice/src/Flight/SpiceFlightClient.cs
+++ b/Spice/src/Flight/SpiceFlightClient.cs
@@ -21,6 +21,7 @@ SOFTWARE.
 */
 
 using System.Net.Http.Headers;
+using System.Security.Cryptography.X509Certificates;
 using Apache.Arrow.Flight;
 using Apache.Arrow.Flight.Client;
 using Grpc.Core;
@@ -39,7 +40,7 @@ internal class SpiceFlightClient : IDisposable
     private readonly HttpClient? _httpClient;
     private readonly AsyncRetryPolicy _retryPolicy;
 
-    private static GrpcChannelOptions GetGrpcChannelOptions(string? appId, string? apiKey, string? userAgent, bool useTls)
+    private static GrpcChannelOptions GetGrpcChannelOptions(string? appId, string? apiKey, string? userAgent, bool useTls, string? tlsClientCertFile = null, string? tlsClientKeyFile = null, string? tlsRootCertFile = null)
     {
         var options = new GrpcChannelOptions();
 
@@ -57,12 +58,27 @@ internal class SpiceFlightClient : IDisposable
                 var handler = new SocketsHttpHandler
                 {
                     EnableMultipleHttp2Connections = true,
-                    // Force periodic connection recycling to trigger DNS re-resolution.
-                    // Without this, HTTP/2 connections are kept alive indefinitely and
-                    // the client can get stuck on stale IPs when backend targets change
-                    // (e.g. AWS ALB target rotation).
                     PooledConnectionLifetime = TimeSpan.FromMinutes(5),
                 };
+                if (tlsClientCertFile != null && tlsClientKeyFile != null)
+                {
+                    var clientCert = X509Certificate2.CreateFromPemFile(tlsClientCertFile, tlsClientKeyFile);
+                    handler.SslOptions.ClientCertificates = new X509Certificate2Collection { clientCert };
+                }
+                if (tlsRootCertFile != null)
+                {
+                    #pragma warning disable SYSLIB0057
+                    var caCert = new X509Certificate2(tlsRootCertFile);
+#pragma warning restore SYSLIB0057
+                    handler.SslOptions.RemoteCertificateValidationCallback = (sender, cert, chain, errors) =>
+                    {
+                        if (errors == System.Net.Security.SslPolicyErrors.None) return true;
+                        if (cert == null || chain == null) return false;
+                        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                        chain.ChainPolicy.CustomTrustStore.Add(caCert);
+                        return chain.Build(new X509Certificate2(cert));
+                    };
+                }
                 options.HttpHandler = handler;
             }
 #endif
@@ -77,15 +93,31 @@ internal class SpiceFlightClient : IDisposable
 #if NET8_0_OR_GREATER
         if (useTls)
         {
-            messageHandler = new SocketsHttpHandler
+            var handler = new SocketsHttpHandler
             {
                 EnableMultipleHttp2Connections = true,
-                // Force periodic connection recycling to trigger DNS re-resolution.
-                // Without this, HTTP/2 connections are kept alive indefinitely and
-                // the client can get stuck on stale IPs when backend targets change
-                // (e.g. AWS ALB target rotation).
                 PooledConnectionLifetime = TimeSpan.FromMinutes(5),
             };
+            if (tlsClientCertFile != null && tlsClientKeyFile != null)
+            {
+                var clientCert = X509Certificate2.CreateFromPemFile(tlsClientCertFile, tlsClientKeyFile);
+                handler.SslOptions.ClientCertificates = new X509Certificate2Collection { clientCert };
+            }
+            if (tlsRootCertFile != null)
+            {
+                #pragma warning disable SYSLIB0057
+                    var caCert = new X509Certificate2(tlsRootCertFile);
+#pragma warning restore SYSLIB0057
+                handler.SslOptions.RemoteCertificateValidationCallback = (sender, cert, chain, errors) =>
+                {
+                    if (errors == System.Net.Security.SslPolicyErrors.None) return true;
+                    if (cert == null || chain == null) return false;
+                    chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                    chain.ChainPolicy.CustomTrustStore.Add(caCert);
+                    return chain.Build(new X509Certificate2(cert));
+                };
+            }
+            messageHandler = handler;
         }
         else
 #endif
@@ -112,13 +144,13 @@ internal class SpiceFlightClient : IDisposable
         return responseHeaders.Get("authorization") ?? trailers.Get("authorization");
     }
 
-    internal SpiceFlightClient(string address, int maxRetries, string? appId, string? apiKey, string? userAgent, bool useTls)
+    internal SpiceFlightClient(string address, int maxRetries, string? appId, string? apiKey, string? userAgent, bool useTls, string? tlsClientCertFile = null, string? tlsClientKeyFile = null, string? tlsRootCertFile = null)
     {
         _retryPolicy = RetryPolicyFactory.CreateRpcRetryPolicy(
             maxRetries,
             (ex, ts, attempt) => RetryPolicyFactory.LogRetry("Flight", ex, ts, attempt));
 
-        var options = GetGrpcChannelOptions(appId, apiKey, userAgent, useTls);
+        var options = GetGrpcChannelOptions(appId, apiKey, userAgent, useTls, tlsClientCertFile, tlsClientKeyFile, tlsRootCertFile);
         _httpClient = options.HttpClient;
 
         _channel = GrpcChannel.ForAddress(address, options);

--- a/Spice/src/Http/SpiceHttpClient.cs
+++ b/Spice/src/Http/SpiceHttpClient.cs
@@ -35,7 +35,8 @@ internal class SpiceHttpClient : ISpiceHttpClient
     private readonly string _httpAddress;
     private bool _disposed;
 
-    internal SpiceHttpClient(string httpAddress, string? appId, string? apiKey, string? userAgent)
+    internal SpiceHttpClient(string httpAddress, string? appId, string? apiKey, string? userAgent,
+        string? tlsClientCertFile = null, string? tlsClientKeyFile = null, string? tlsRootCertFile = null)
     {
 #if NET8_0_OR_GREATER
         ArgumentException.ThrowIfNullOrWhiteSpace(httpAddress);
@@ -44,7 +45,42 @@ internal class SpiceHttpClient : ISpiceHttpClient
 #endif
 
         _httpAddress = httpAddress;
-        _httpClient = new HttpClient();
+
+#if NET8_0_OR_GREATER
+        if (tlsClientCertFile != null || tlsRootCertFile != null)
+        {
+            var handler = new SocketsHttpHandler
+            {
+                PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            };
+            if (tlsClientCertFile != null && tlsClientKeyFile != null)
+            {
+                var clientCert = System.Security.Cryptography.X509Certificates.X509Certificate2.CreateFromPemFile(
+                    tlsClientCertFile, tlsClientKeyFile);
+                handler.SslOptions.ClientCertificates =
+                    new System.Security.Cryptography.X509Certificates.X509Certificate2Collection { clientCert };
+            }
+            if (tlsRootCertFile != null)
+            {
+#pragma warning disable SYSLIB0057
+                var caCert = new System.Security.Cryptography.X509Certificates.X509Certificate2(tlsRootCertFile);
+#pragma warning restore SYSLIB0057
+                handler.SslOptions.RemoteCertificateValidationCallback = (sender, cert, chain, errors) =>
+                {
+                    if (errors == System.Net.Security.SslPolicyErrors.None) return true;
+                    if (cert == null || chain == null) return false;
+                    chain.ChainPolicy.TrustMode = System.Security.Cryptography.X509Certificates.X509ChainTrustMode.CustomRootTrust;
+                    chain.ChainPolicy.CustomTrustStore.Add(caCert);
+                    return chain.Build(new System.Security.Cryptography.X509Certificates.X509Certificate2(cert));
+                };
+            }
+            _httpClient = new HttpClient(handler);
+        }
+        else
+#endif
+        {
+            _httpClient = new HttpClient();
+        }
 
         // Set authorization if credentials provided
         if (!string.IsNullOrEmpty(appId) && !string.IsNullOrEmpty(apiKey))

--- a/Spice/src/SpiceClient.cs
+++ b/Spice/src/SpiceClient.cs
@@ -66,6 +66,24 @@ public class SpiceClient : IDisposable
     /// </summary>
     public bool UseTls { get; internal set; }
 
+    /// <summary>
+    /// Gets or sets the path to a PEM-encoded client certificate file for mTLS.
+    /// Must be used together with <see cref="TlsClientKeyFile"/>.
+    /// </summary>
+    public string? TlsClientCertFile { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets the path to a PEM-encoded client private key file for mTLS.
+    /// Must be used together with <see cref="TlsClientCertFile"/>.
+    /// </summary>
+    public string? TlsClientKeyFile { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets the path to a PEM-encoded CA certificate file for server verification.
+    /// When set, this CA is used instead of the system certificate store.
+    /// </summary>
+    public string? TlsRootCertFile { get; internal set; }
+
     private SpiceFlightClient? FlightClient { get; set; }
     private SpiceAdbcClient? AdbcClient { get; set; }
     private SpiceHttpClient? HttpClient { get; set; }
@@ -73,9 +91,19 @@ public class SpiceClient : IDisposable
 
     internal void Init()
     {
-        FlightClient = new SpiceFlightClient(FlightAddress, MaxRetries, AppId, ApiKey, UserAgent, UseTls);
+        // Validate that client cert and key are either both set or both unset
+        bool hasCert = !string.IsNullOrEmpty(TlsClientCertFile);
+        bool hasKey = !string.IsNullOrEmpty(TlsClientKeyFile);
+        if (hasCert != hasKey)
+        {
+            var missing = hasCert ? nameof(TlsClientKeyFile) : nameof(TlsClientCertFile);
+            throw new InvalidOperationException(
+                $"Both {nameof(TlsClientCertFile)} and {nameof(TlsClientKeyFile)} must be provided together for mTLS. {missing} is missing.");
+        }
+
+        FlightClient = new SpiceFlightClient(FlightAddress, MaxRetries, AppId, ApiKey, UserAgent, UseTls, TlsClientCertFile, TlsClientKeyFile, TlsRootCertFile);
         AdbcClient = new SpiceAdbcClient(FlightAddress, MaxRetries, AppId, ApiKey, UserAgent, UseTls);
-        HttpClient = new SpiceHttpClient(HttpAddress, AppId, ApiKey, UserAgent);
+        HttpClient = new SpiceHttpClient(HttpAddress, AppId, ApiKey, UserAgent, TlsClientCertFile, TlsClientKeyFile, TlsRootCertFile);
     }
 
     /// <summary>

--- a/Spice/src/SpiceClientBuilder.cs
+++ b/Spice/src/SpiceClientBuilder.cs
@@ -149,6 +149,32 @@ public class SpiceClientBuilder
     }
 
     /// <summary>
+    /// Sets the paths to PEM-encoded client certificate and key files for mTLS.
+    /// </summary>
+    /// <param name="certFile">Path to the client certificate PEM file.</param>
+    /// <param name="keyFile">Path to the client private key PEM file.</param>
+    /// <returns>The current instance of <see cref="SpiceClientBuilder"/> for method chaining.</returns>
+    public SpiceClientBuilder WithTlsClientCertificate(string certFile, string keyFile)
+    {
+        _spiceClient.TlsClientCertFile = certFile;
+        _spiceClient.TlsClientKeyFile = keyFile;
+        _spiceClient.UseTls = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the path to a PEM-encoded CA certificate file for server verification.
+    /// </summary>
+    /// <param name="caFile">Path to the CA certificate PEM file.</param>
+    /// <returns>The current instance of <see cref="SpiceClientBuilder"/> for method chaining.</returns>
+    public SpiceClientBuilder WithTlsRootCertificate(string caFile)
+    {
+        _spiceClient.TlsRootCertFile = caFile;
+        _spiceClient.UseTls = true;
+        return this;
+    }
+
+    /// <summary>
     /// Initiates <see cref="SpiceClient" /> with provided parameters.
     /// </summary>
     /// <returns>The current instance of <see cref="SpiceClient"/> for method chaining.</returns>


### PR DESCRIPTION
Adds mTLS (mutual TLS) client certificate support, allowing the SDK to present a client certificate during the TLS handshake when connecting to a Spice runtime with `client_auth_mode: request` or `client_auth_mode: required`.

## Usage

Provide the paths to a PEM-encoded client certificate and private key file when building the client. The certificate is presented to the server during the TLS handshake.

## Notes

- mTLS is an [Enterprise](https://docs.spice.ai/docs/enterprise) feature of the Spice runtime.
- Both the certificate and key file must be provided together.
- When not set, the client behaves exactly as before (standard TLS).
- See the [mTLS cookbook recipe](https://github.com/spiceai/cookbook/tree/trunk/mtls) for a complete walkthrough.