### PR TITLE
feat: add SearchAsync for vector, keyword, and hybrid search

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,50 @@ using var client = new SpiceClientBuilder()
 await client.RefreshDatasetAsync("my_dataset");
 ```
 
+#### Search
+
+`SearchAsync` runs vector similarity, keyword, and hybrid search against datasets that have
+an embedding column and a loaded embedding model.
+
+```csharp
+using Spice;
+using Spice.Search;
+
+using var client = new SpiceClientBuilder().Build();
+
+var response = await client.SearchAsync(new SearchRequest("tickets to Tokyo")
+{
+    Datasets = new[] { "app_messages" },
+    Limit = 3,
+});
+
+Console.WriteLine($"{response.Results.Count} matches in {response.DurationMs}ms");
+foreach (var match in response.Results)
+{
+    Console.WriteLine($"{match.Dataset} {match.Score}");
+}
+```
+
+Only `Text` is required. `Datasets` restricts the search — leave it unset to search every
+dataset with an embedding column. `Limit` caps matches per dataset, `Where` applies an SQL
+predicate before the search, and `AdditionalColumns` names extra columns to return. Setting
+`Keywords` pre-filters the embedding column with a lexical search before the vector search
+runs, making the search hybrid:
+
+```csharp
+var response = await client.SearchAsync(new SearchRequest("tickets to Tokyo")
+{
+    Where = "city = 'Tokyo'",
+    AdditionalColumns = new[] { "timestamp" },
+    Keywords = new[] { "plane", "tickets" },
+});
+```
+
+Each `SearchMatch` carries the `Dataset` it was found in, its similarity `Score`, the
+matched column values in `Matches`, the row's `PrimaryKey`, the columns requested via
+`AdditionalColumns` in `Data`, and any `Metadata`. The runtime omits the last three when
+empty; they default to empty dictionaries, so they can be read without a null check.
+
 ### Memory Management
 
 The `SpiceClient` implements `IDisposable` and should be properly disposed to release network resources (gRPC channels, HTTP clients). Use the `using` statement or `using` declaration for automatic disposal:

--- a/Spice/Spice.csproj
+++ b/Spice/Spice.csproj
@@ -56,12 +56,12 @@
     </ItemGroup>
 
     <!--
-        System.Text.Json arrives transitively via Apache.Arrow.Adbc, but search
-        serialization depends on it directly, so pin it explicitly. The version matches
-        what Apache.Arrow.Adbc already resolves to; netstandard2.0 needs the package
-        because, unlike net8.0+, it has no in-box System.Text.Json.
+        netstandard2.0 has no in-box System.Text.Json, so it needs the package. net8.0+
+        ship it in the framework, and referencing it there would push an unnecessary
+        dependency constraint onto consumers. The version matches what
+        Apache.Arrow.Adbc already resolves to, so netstandard2.0 sees no downgrade.
     -->
-    <ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="System.Text.Json" Version="9.0.9" />
     </ItemGroup>
 

--- a/Spice/Spice.csproj
+++ b/Spice/Spice.csproj
@@ -55,4 +55,14 @@
         </AssemblyAttribute>
     </ItemGroup>
 
+    <!--
+        System.Text.Json arrives transitively via Apache.Arrow.Adbc, but search
+        serialization depends on it directly, so pin it explicitly. The version matches
+        what Apache.Arrow.Adbc already resolves to; netstandard2.0 needs the package
+        because, unlike net8.0+, it has no in-box System.Text.Json.
+    -->
+    <ItemGroup>
+        <PackageReference Include="System.Text.Json" Version="9.0.9" />
+    </ItemGroup>
+
 </Project>

--- a/Spice/src/Errors/SpiceException.cs
+++ b/Spice/src/Errors/SpiceException.cs
@@ -36,4 +36,10 @@ public class SpiceException : Exception
     {
         Status = status;
     }
+
+    internal SpiceException(SpiceStatus status, string message, Exception? innerException)
+        : base(message, innerException)
+    {
+        Status = status;
+    }
 }

--- a/Spice/src/Flight/SpiceFlightClient.cs
+++ b/Spice/src/Flight/SpiceFlightClient.cs
@@ -166,15 +166,81 @@ internal class SpiceFlightClient : IDisposable
     {
         var stream = _flightClient.Handshake();
 
-        var headers = await stream.ResponseHeadersAsync.ConfigureAwait(false);
-        var token = GetAuthToken(headers, stream.GetTrailers());
-        
+        Metadata headers;
+        try
+        {
+            headers = await stream.ResponseHeadersAsync.ConfigureAwait(false);
+        }
+        catch (RpcException ex)
+        {
+            throw new SpiceException(
+                SpiceStatus.FailedToAuthenticate,
+                $"Failed to authenticate: {DescribeRpcFailure(ex)}",
+                ex);
+        }
+
+        // Trailers are only readable once the call has completed. Reading them
+        // eagerly throws InvalidOperationException on a handshake that failed,
+        // which masks the gRPC status that says what actually went wrong.
+        RpcException? failure = null;
+        var token = headers.Get("authorization");
+        if (token == null)
+        {
+            token = TryGetTrailerToken(stream, out failure);
+        }
+
         if (token == null || _httpClient == null)
         {
-            throw new SpiceException(SpiceStatus.FailedToAuthenticate, "Failed to authenticate");
+            var reason = failure == null
+                ? "the runtime returned no authorization token."
+                : DescribeRpcFailure(failure);
+
+            throw new SpiceException(
+                SpiceStatus.FailedToAuthenticate,
+                $"Failed to authenticate: {reason} Check that the API key is valid for this endpoint.",
+                failure);
         }
 
         _httpClient.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(token.Value);
+    }
+
+    /// <summary>
+    /// Reads the authorization token from the handshake trailers, if the call
+    /// completed far enough for them to be available.
+    /// </summary>
+    /// <param name="stream">The handshake call</param>
+    /// <param name="failure">The gRPC failure, when the trailers could not be read</param>
+    /// <returns>The token entry, or null</returns>
+    private static Metadata.Entry? TryGetTrailerToken(
+        AsyncDuplexStreamingCall<FlightHandshakeRequest, FlightHandshakeResponse> stream,
+        out RpcException? failure)
+    {
+        failure = null;
+        try
+        {
+            return stream.GetTrailers().Get("authorization");
+        }
+        catch (RpcException ex)
+        {
+            failure = ex;
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            // The handshake never completed, so there are no trailers to read.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Renders a gRPC failure as something a caller can act on.
+    /// </summary>
+    /// <param name="ex">The gRPC exception</param>
+    /// <returns>A short description of the failure</returns>
+    private static string DescribeRpcFailure(RpcException ex)
+    {
+        var detail = string.IsNullOrWhiteSpace(ex.Status.Detail) ? ex.Message : ex.Status.Detail;
+        return $"{ex.StatusCode} - {detail}.";
     }
 
     internal async Task<FlightClientRecordBatchStreamReader> Query(string sql)

--- a/Spice/src/Http/ISpiceHttpClient.cs
+++ b/Spice/src/Http/ISpiceHttpClient.cs
@@ -20,6 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+using Spice.Search;
+
 namespace Spice.Http;
 
 /// <summary>
@@ -44,4 +46,15 @@ public interface ISpiceHttpClient : IDisposable
     /// <exception cref="System.ArgumentException">Thrown when datasetName is null or empty</exception>
     /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
     Task RefreshDatasetAsync(string datasetName);
+
+    /// <summary>
+    /// Runs a vector, keyword, or hybrid search against datasets with an embedding column.
+    /// </summary>
+    /// <param name="request">The search to run</param>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>The matches, ordered by descending score</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown when request is null</exception>
+    /// <exception cref="System.ArgumentException">Thrown when the search text is null or empty</exception>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    Task<SearchResponse> SearchAsync(SearchRequest request, CancellationToken cancellationToken = default);
 }

--- a/Spice/src/Http/SpiceHttpClient.cs
+++ b/Spice/src/Http/SpiceHttpClient.cs
@@ -160,11 +160,11 @@ internal class SpiceHttpClient : ISpiceHttpClient
 #if NET8_0_OR_GREATER
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(request);
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.Text, nameof(request));
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Text, $"{nameof(request)}.{nameof(request.Text)}");
 #else
         if (_disposed) throw new ObjectDisposedException(GetType().FullName);
         ThrowHelper.ThrowIfNull(request, nameof(request));
-        ThrowHelper.ThrowIfNullOrWhiteSpace(request.Text, nameof(request));
+        ThrowHelper.ThrowIfNullOrWhiteSpace(request.Text, $"{nameof(request)}.{nameof(request.Text)}");
 #endif
 
         var url = $"{_httpAddress}/v1/search";

--- a/Spice/src/Http/SpiceHttpClient.cs
+++ b/Spice/src/Http/SpiceHttpClient.cs
@@ -22,7 +22,9 @@ SOFTWARE.
 
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json;
 using Spice.Auth;
+using Spice.Search;
 
 namespace Spice.Http;
 
@@ -134,6 +136,89 @@ internal class SpiceHttpClient : ISpiceHttpClient
         var url = $"{_httpAddress}/v1/datasets/{datasetName}/acceleration/refresh";
         var response = await _httpClient.PostAsync(url, null).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
+    }
+
+    /// <summary>
+    /// Options used to serialize search requests and deserialize search responses.
+    /// </summary>
+    private static readonly JsonSerializerOptions SearchJsonOptions = new()
+    {
+        PropertyNamingPolicy = null,
+    };
+
+    /// <summary>
+    /// Runs a vector, keyword, or hybrid search against datasets with an embedding column.
+    /// </summary>
+    /// <param name="request">The search to run</param>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>The matches, ordered by descending score</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown when request is null</exception>
+    /// <exception cref="System.ArgumentException">Thrown when the search text is null or empty</exception>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    public async Task<SearchResponse> SearchAsync(SearchRequest request, CancellationToken cancellationToken = default)
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Text, nameof(request));
+#else
+        if (_disposed) throw new ObjectDisposedException(GetType().FullName);
+        ThrowHelper.ThrowIfNull(request, nameof(request));
+        ThrowHelper.ThrowIfNullOrWhiteSpace(request.Text, nameof(request));
+#endif
+
+        var url = $"{_httpAddress}/v1/search";
+        var json = JsonSerializer.Serialize(request, SearchJsonOptions);
+
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var response = await _httpClient.PostAsync(url, content, cancellationToken).ConfigureAwait(false);
+
+#if NET8_0_OR_GREATER
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        // netstandard2.0 has no CancellationToken overload for ReadAsStringAsync.
+        var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+
+        if (!response.IsSuccessStatusCode)
+        {
+            // Surface the runtime's own message — it names what the caller needs to fix.
+            throw new HttpRequestException(
+                $"Search failed with status {(int)response.StatusCode}: {ExtractErrorMessage(body)}");
+        }
+
+        return JsonSerializer.Deserialize<SearchResponse>(body, SearchJsonOptions) ?? new SearchResponse();
+    }
+
+    /// <summary>
+    /// Pulls the runtime's error message out of a failed response body, falling back to
+    /// the raw body when it is not the expected shape.
+    /// </summary>
+    /// <param name="body">The response body</param>
+    /// <returns>The message to report</returns>
+    private static string ExtractErrorMessage(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return "(no response body)";
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(body);
+            if (document.RootElement.ValueKind == JsonValueKind.Object
+                && document.RootElement.TryGetProperty("error", out var error)
+                && error.ValueKind == JsonValueKind.String)
+            {
+                return error.GetString() ?? body;
+            }
+        }
+        catch (JsonException)
+        {
+            // Not JSON — fall through and report the body verbatim.
+        }
+
+        return body;
     }
 
     /// <summary>

--- a/Spice/src/Search/SearchTypes.cs
+++ b/Spice/src/Search/SearchTypes.cs
@@ -1,0 +1,161 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Spice.Search;
+
+/// <summary>
+/// A search over datasets that have an embedding column and a loaded embedding model.
+/// </summary>
+/// <remarks>
+/// Only <see cref="Text"/> is required. Leave <see cref="Datasets"/> unset to search every
+/// dataset with an embedding column, and set <see cref="Keywords"/> to pre-filter the
+/// embedding column with a lexical search first, making the search hybrid.
+/// </remarks>
+public class SearchRequest
+{
+    /// <summary>
+    /// Creates a search request.
+    /// </summary>
+    /// <param name="text">The query to find similar documents for</param>
+    public SearchRequest(string text)
+    {
+        Text = text;
+    }
+
+    /// <summary>
+    /// The query to find similar documents for.
+    /// </summary>
+    [JsonPropertyName("text")]
+    public string Text { get; set; }
+
+    /// <summary>
+    /// Restricts the search to these datasets. Null searches every dataset with an
+    /// embedding column.
+    /// </summary>
+    [JsonPropertyName("datasets")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? Datasets { get; set; }
+
+    /// <summary>
+    /// Maximum matches to return per dataset. Null uses the runtime's default.
+    /// </summary>
+    [JsonPropertyName("limit")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Limit { get; set; }
+
+    /// <summary>
+    /// An SQL predicate applied before the search, without the WHERE keyword —
+    /// for example <c>city = 'Tokyo'</c>.
+    /// </summary>
+    [JsonPropertyName("where")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Where { get; set; }
+
+    /// <summary>
+    /// Extra dataset columns to return. A column that is part of the primary key is
+    /// returned in <see cref="SearchMatch.PrimaryKey"/> rather than <see cref="SearchMatch.Data"/>.
+    /// </summary>
+    [JsonPropertyName("additional_columns")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? AdditionalColumns { get; set; }
+
+    /// <summary>
+    /// Pre-filters the embedding column with a lexical search before the vector search
+    /// runs, making the search hybrid.
+    /// </summary>
+    [JsonPropertyName("keywords")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? Keywords { get; set; }
+}
+
+/// <summary>
+/// A single document matched by a search.
+/// </summary>
+/// <remarks>
+/// The runtime omits <see cref="Data"/>, <see cref="PrimaryKey"/> and <see cref="Metadata"/>
+/// when they are empty; they default to empty dictionaries so they can be read without a
+/// null check.
+/// </remarks>
+public class SearchMatch
+{
+    /// <summary>
+    /// The dataset the match was found in.
+    /// </summary>
+    [JsonPropertyName("dataset")]
+    public string Dataset { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Similarity of the match to the query text. Higher is closer.
+    /// </summary>
+    /// <remarks>The runtime serializes this as <c>_score</c>.</remarks>
+    [JsonPropertyName("_score")]
+    public double Score { get; set; }
+
+    /// <summary>
+    /// The matched values of each searched column.
+    /// </summary>
+    [JsonPropertyName("matches")]
+    public IReadOnlyDictionary<string, IReadOnlyList<JsonElement>> Matches { get; set; }
+        = new Dictionary<string, IReadOnlyList<JsonElement>>();
+
+    /// <summary>
+    /// Primary key identifying the matched row, if the dataset declares one.
+    /// </summary>
+    [JsonPropertyName("primary_key")]
+    public IReadOnlyDictionary<string, JsonElement> PrimaryKey { get; set; }
+        = new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Columns requested via <see cref="SearchRequest.AdditionalColumns"/>.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public IReadOnlyDictionary<string, JsonElement> Data { get; set; }
+        = new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Any additional metadata the runtime attached to the match.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public IReadOnlyDictionary<string, JsonElement> Metadata { get; set; }
+        = new Dictionary<string, JsonElement>();
+}
+
+/// <summary>
+/// The result of a search.
+/// </summary>
+public class SearchResponse
+{
+    /// <summary>
+    /// Matches, ordered by descending score.
+    /// </summary>
+    [JsonPropertyName("results")]
+    public IReadOnlyList<SearchMatch> Results { get; set; } = new List<SearchMatch>();
+
+    /// <summary>
+    /// How long the runtime took to run the search.
+    /// </summary>
+    [JsonPropertyName("duration_ms")]
+    public long DurationMs { get; set; }
+}

--- a/Spice/src/SpiceClient.cs
+++ b/Spice/src/SpiceClient.cs
@@ -26,6 +26,7 @@ using Spice.Adbc;
 using Spice.Config;
 using Spice.Flight;
 using Spice.Http;
+using Spice.Search;
 
 namespace Spice;
 
@@ -187,6 +188,33 @@ public class SpiceClient : IDisposable
         if (HttpClient == null) throw new InvalidOperationException("HttpClient not initialized");
 
         return HttpClient.RefreshDatasetAsync(datasetName);
+    }
+
+    /// <summary>
+    /// Runs a vector, keyword, or hybrid search.
+    /// </summary>
+    /// <remarks>
+    /// Searches datasets that have an embedding column and a loaded embedding model,
+    /// returning the documents most similar to the request text. Setting
+    /// <see cref="SearchRequest.Keywords"/> pre-filters the embedding column with a
+    /// lexical search first, making the search hybrid.
+    /// </remarks>
+    /// <param name="request">The search to run</param>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>The matches, ordered by descending score</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown when request is null</exception>
+    /// <exception cref="System.ArgumentException">Thrown when the search text is null or empty</exception>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    public Task<SearchResponse> SearchAsync(SearchRequest request, CancellationToken cancellationToken = default)
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(_disposed, this);
+#else
+        if (_disposed) throw new ObjectDisposedException(GetType().FullName);
+#endif
+        if (HttpClient == null) throw new InvalidOperationException("HttpClient not initialized");
+
+        return HttpClient.SearchAsync(request, cancellationToken);
     }
 
     private bool _disposed;

--- a/SpiceTest/SearchTest.cs
+++ b/SpiceTest/SearchTest.cs
@@ -1,0 +1,187 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+using NUnit.Framework;
+using Spice.Search;
+
+namespace SpiceTest;
+
+/// <summary>
+/// Unit tests for search request serialization and response deserialization.
+/// </summary>
+/// <remarks>
+/// These cover the wire contract of <c>/v1/search</c>, which is where the SDK and the
+/// runtime have to agree exactly.
+/// </remarks>
+[TestFixture]
+public class SearchTest
+{
+    private static readonly string[] ExpectedDatasetOrder = { "a", "b" };
+
+    private static string Serialize(SearchRequest request) => JsonSerializer.Serialize(request);
+
+    private static SearchResponse Deserialize(string json) =>
+        JsonSerializer.Deserialize<SearchResponse>(json)!;
+
+    // ==================== Request serialization ====================
+
+    [Test]
+    public void Test_Request_TextOnly_OmitsOptionalFields()
+    {
+        var json = Serialize(new SearchRequest("tickets to Tokyo"));
+
+        Assert.That(json, Is.EqualTo("{\"text\":\"tickets to Tokyo\"}"));
+    }
+
+    [Test]
+    public void Test_Request_AllOptions_UseWireNames()
+    {
+        var request = new SearchRequest("tickets to Tokyo")
+        {
+            Datasets = new[] { "app_messages" },
+            Limit = 3,
+            Where = "city = 'Tokyo'",
+            AdditionalColumns = new[] { "timestamp" },
+            Keywords = new[] { "plane", "tickets" },
+        };
+
+        using var document = JsonDocument.Parse(Serialize(request));
+        var root = document.RootElement;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(root.GetProperty("text").GetString(), Is.EqualTo("tickets to Tokyo"));
+            Assert.That(root.GetProperty("datasets").GetArrayLength(), Is.EqualTo(1));
+            Assert.That(root.GetProperty("limit").GetInt32(), Is.EqualTo(3));
+            Assert.That(root.GetProperty("where").GetString(), Is.EqualTo("city = 'Tokyo'"));
+            Assert.That(root.GetProperty("additional_columns").GetArrayLength(), Is.EqualTo(1));
+            Assert.That(root.GetProperty("keywords").GetArrayLength(), Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void Test_Request_LimitZero_IsPreserved()
+    {
+        // 0 is a real value the caller supplied, distinct from unset.
+        var json = Serialize(new SearchRequest("tickets") { Limit = 0 });
+
+        Assert.That(json, Does.Contain("\"limit\":0"));
+    }
+
+    [Test]
+    public void Test_Request_EmptyCollections_AreSentNotDropped()
+    {
+        var json = Serialize(new SearchRequest("tickets") { Datasets = Array.Empty<string>() });
+
+        Assert.That(json, Does.Contain("\"datasets\":[]"));
+    }
+
+    // ==================== Response deserialization ====================
+
+    [Test]
+    public void Test_Response_DeserializesWireFormat()
+    {
+        const string body = """
+        {
+            "results": [
+                {
+                    "matches": {"message": ["I booked us some tickets"]},
+                    "dataset": "app_messages",
+                    "primary_key": {"id": "6fd5a215"},
+                    "data": {"timestamp": 1724716542},
+                    "_score": 0.914321
+                }
+            ],
+            "duration_ms": 42
+        }
+        """;
+
+        var response = Deserialize(body);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.DurationMs, Is.EqualTo(42));
+            Assert.That(response.Results, Has.Count.EqualTo(1));
+            Assert.That(response.Results[0].Dataset, Is.EqualTo("app_messages"));
+            Assert.That(response.Results[0].Score, Is.EqualTo(0.914321).Within(1e-9));
+            Assert.That(response.Results[0].PrimaryKey["id"].GetString(), Is.EqualTo("6fd5a215"));
+            Assert.That(response.Results[0].Data["timestamp"].GetInt64(), Is.EqualTo(1724716542));
+            Assert.That(response.Results[0].Matches["message"], Has.Count.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Test_Response_ScoreReadsUnderscorePrefixedWireField()
+    {
+        // The runtime serializes the similarity as `_score`, not `score`.
+        var response = Deserialize("""{"results":[{"dataset":"a","_score":0.75}],"duration_ms":1}""");
+
+        Assert.That(response.Results[0].Score, Is.EqualTo(0.75).Within(1e-9));
+    }
+
+    [Test]
+    public void Test_Response_OmittedObjects_DefaultToEmptyNotNull()
+    {
+        // The runtime omits data/primary_key/metadata entirely when empty.
+        var response = Deserialize("""{"results":[{"dataset":"a","_score":0.5}],"duration_ms":1}""");
+        var match = response.Results[0];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(match.Data, Is.Not.Null.And.Empty);
+            Assert.That(match.PrimaryKey, Is.Not.Null.And.Empty);
+            Assert.That(match.Metadata, Is.Not.Null.And.Empty);
+            Assert.That(match.Matches, Is.Not.Null.And.Empty);
+        });
+    }
+
+    [Test]
+    public void Test_Response_EmptyResults()
+    {
+        var response = Deserialize("""{"results":[],"duration_ms":0}""");
+
+        Assert.That(response.Results, Is.Empty);
+    }
+
+    [Test]
+    public void Test_Response_MissingResultsKey_YieldsEmptyList()
+    {
+        var response = Deserialize("""{"duration_ms":7}""");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.Results, Is.Not.Null.And.Empty);
+            Assert.That(response.DurationMs, Is.EqualTo(7));
+        });
+    }
+
+    [Test]
+    public void Test_Response_RoundTripsMultipleMatchesInOrder()
+    {
+        var response = Deserialize("""
+        {"results":[{"dataset":"a","_score":0.9},{"dataset":"b","_score":0.8}],"duration_ms":2}
+        """);
+
+        Assert.That(response.Results.Select(m => m.Dataset), Is.EqualTo(ExpectedDatasetOrder));
+    }
+}


### PR DESCRIPTION
## What

Adds `SpiceClient.SearchAsync`, wrapping the runtime's `POST /v1/search` — vector similarity, keyword, and hybrid search over datasets with an embedding column.

```csharp
var response = await client.SearchAsync(new SearchRequest("tickets to Tokyo")
{
    Datasets = new[] { "app_messages" },
    Limit = 3,
});
```

Only `Text` is required. Setting `Keywords` pre-filters the embedding column with a lexical search before the vector search runs, making the search hybrid.

New public types in `Spice.Search`: `SearchRequest`, `SearchResponse`, `SearchMatch`.

## Why

`/v1/search` works on a default `spice run` and is a distinctive Spice capability, but .NET users had no way to reach it short of hand-rolling the HTTP call. spice.js is currently the only SDK that exposes it.

Two wire-format details the types handle so callers don't have to:

- the similarity score is serialized as `_score`, not `score`
- `data`, `primary_key` and `metadata` are omitted entirely when empty, so they default to empty dictionaries rather than null — readable without a guard

On a failed search the runtime's own `{"error": "..."}` message is surfaced rather than a bare status code, since that message names what the caller needs to fix.

Part of aligning search support across the SDKs.

## Notes for review

- **`System.Text.Json` is now an explicit `PackageReference`.** It was already resolved transitively through `Apache.Arrow.Adbc` (which requires `>= 9.0.9`); this pins the same version explicitly because the search path depends on it directly, and `netstandard2.0` has no in-box `System.Text.Json`. Pinning below 9.0.9 fails the build with `NU1605`.
- **`ReadAsStringAsync` is `#if`-split** — the `CancellationToken` overload doesn't exist on `netstandard2.0`, and the analyzers treat `CA2016` as an error on the modern targets.
- This repo has #20 (health/readiness) and #21 (refresh options) open, both touching `SpiceClient.cs` and the HTTP client. This branch adds new members rather than changing existing ones, but it will want a merge rather than a fast-forward if those land first.

## Verification

- [x] `dotnet build -c Release` — all four targets, `netstandard2.0` included
- [x] `dotnet test` — 125 passed, 0 failed on each of net8.0 / net9.0 / net10.0, including 10 new tests in `SearchTest.cs` covering request serialization (wire field names, `limit: 0`, empty collections) and response deserialization (`_score`, omitted objects, missing keys)
- [x] Verified against a live `spice run`: the search request reaches `/v1/search`, and a
      failure surfaces the runtime's own message (`"Search cannot be run on <dataset> because it
      has no embeddings or full text search indexes."`) rather than a bare status code
- [ ] A search returning matches was not exercised end to end — that needs a dataset with an
      embedding column and a loaded embedding model, which this environment has no credentials for. The 33 skipped tests are the existing suites that require one.
