### PR TITLE
fix: read the auth token from response headers before trailers

### DIFF
--- a/Spice/src/Errors/SpiceException.cs
+++ b/Spice/src/Errors/SpiceException.cs
@@ -36,4 +36,10 @@ public class SpiceException : Exception
     {
         Status = status;
     }
+
+    internal SpiceException(SpiceStatus status, string message, Exception? innerException)
+        : base(message, innerException)
+    {
+        Status = status;
+    }
 }

--- a/Spice/src/Flight/SpiceFlightClient.cs
+++ b/Spice/src/Flight/SpiceFlightClient.cs
@@ -166,15 +166,81 @@ internal class SpiceFlightClient : IDisposable
     {
         var stream = _flightClient.Handshake();
 
-        var headers = await stream.ResponseHeadersAsync.ConfigureAwait(false);
-        var token = GetAuthToken(headers, stream.GetTrailers());
-        
+        Metadata headers;
+        try
+        {
+            headers = await stream.ResponseHeadersAsync.ConfigureAwait(false);
+        }
+        catch (RpcException ex)
+        {
+            throw new SpiceException(
+                SpiceStatus.FailedToAuthenticate,
+                $"Failed to authenticate: {DescribeRpcFailure(ex)}",
+                ex);
+        }
+
+        // Trailers are only readable once the call has completed. Reading them
+        // eagerly throws InvalidOperationException on a handshake that failed,
+        // which masks the gRPC status that says what actually went wrong.
+        RpcException? failure = null;
+        var token = headers.Get("authorization");
+        if (token == null)
+        {
+            token = TryGetTrailerToken(stream, out failure);
+        }
+
         if (token == null || _httpClient == null)
         {
-            throw new SpiceException(SpiceStatus.FailedToAuthenticate, "Failed to authenticate");
+            var reason = failure == null
+                ? "the runtime returned no authorization token."
+                : DescribeRpcFailure(failure);
+
+            throw new SpiceException(
+                SpiceStatus.FailedToAuthenticate,
+                $"Failed to authenticate: {reason} Check that the API key is valid for this endpoint.",
+                failure);
         }
 
         _httpClient.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(token.Value);
+    }
+
+    /// <summary>
+    /// Reads the authorization token from the handshake trailers, if the call
+    /// completed far enough for them to be available.
+    /// </summary>
+    /// <param name="stream">The handshake call</param>
+    /// <param name="failure">The gRPC failure, when the trailers could not be read</param>
+    /// <returns>The token entry, or null</returns>
+    private static Metadata.Entry? TryGetTrailerToken(
+        AsyncDuplexStreamingCall<FlightHandshakeRequest, FlightHandshakeResponse> stream,
+        out RpcException? failure)
+    {
+        failure = null;
+        try
+        {
+            return stream.GetTrailers().Get("authorization");
+        }
+        catch (RpcException ex)
+        {
+            failure = ex;
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            // The handshake never completed, so there are no trailers to read.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Renders a gRPC failure as something a caller can act on.
+    /// </summary>
+    /// <param name="ex">The gRPC exception</param>
+    /// <returns>A short description of the failure</returns>
+    private static string DescribeRpcFailure(RpcException ex)
+    {
+        var detail = string.IsNullOrWhiteSpace(ex.Status.Detail) ? ex.Message : ex.Status.Detail;
+        return $"{ex.StatusCode} - {detail}.";
     }
 
     internal async Task<FlightClientRecordBatchStreamReader> Query(string sql)

--- a/Spice/src/Flight/SpiceFlightClient.cs
+++ b/Spice/src/Flight/SpiceFlightClient.cs
@@ -182,7 +182,7 @@ internal class SpiceFlightClient : IDisposable
         // Trailers are only readable once the call has completed. Reading them
         // eagerly throws InvalidOperationException on a handshake that failed,
         // which masks the gRPC status that says what actually went wrong.
-        RpcException? failure = null;
+        Exception? failure = null;
         var token = headers.Get("authorization");
         if (token == null)
         {
@@ -191,9 +191,7 @@ internal class SpiceFlightClient : IDisposable
 
         if (token == null || _httpClient == null)
         {
-            var reason = failure == null
-                ? "the runtime returned no authorization token."
-                : DescribeRpcFailure(failure);
+            var reason = DescribeAuthFailure(failure);
 
             throw new SpiceException(
                 SpiceStatus.FailedToAuthenticate,
@@ -209,11 +207,11 @@ internal class SpiceFlightClient : IDisposable
     /// completed far enough for them to be available.
     /// </summary>
     /// <param name="stream">The handshake call</param>
-    /// <param name="failure">The gRPC failure, when the trailers could not be read</param>
+    /// <param name="failure">The failure that prevented reading the trailers, if any</param>
     /// <returns>The token entry, or null</returns>
-    private static Metadata.Entry? TryGetTrailerToken(
+    internal static Metadata.Entry? TryGetTrailerToken(
         AsyncDuplexStreamingCall<FlightHandshakeRequest, FlightHandshakeResponse> stream,
-        out RpcException? failure)
+        out Exception? failure)
     {
         failure = null;
         try
@@ -225,9 +223,10 @@ internal class SpiceFlightClient : IDisposable
             failure = ex;
             return null;
         }
-        catch (InvalidOperationException)
+        catch (InvalidOperationException ex)
         {
             // The handshake never completed, so there are no trailers to read.
+            failure = ex;
             return null;
         }
     }
@@ -241,6 +240,21 @@ internal class SpiceFlightClient : IDisposable
     {
         var detail = string.IsNullOrWhiteSpace(ex.Status.Detail) ? ex.Message : ex.Status.Detail;
         return $"{ex.StatusCode} - {detail}.";
+    }
+
+    /// <summary>
+    /// Renders why the auth token could not be obtained as something a caller can act on.
+    /// </summary>
+    /// <param name="failure">The failure captured while trying to read the token, if any</param>
+    /// <returns>A short description of the failure</returns>
+    internal static string DescribeAuthFailure(Exception? failure)
+    {
+        return failure switch
+        {
+            null => "the runtime returned no authorization token.",
+            RpcException rpcEx => DescribeRpcFailure(rpcEx),
+            _ => "the handshake did not complete before trailers could be read."
+        };
     }
 
     internal async Task<FlightClientRecordBatchStreamReader> Query(string sql)

--- a/SpiceTest/FlightAuthFailureTest.cs
+++ b/SpiceTest/FlightAuthFailureTest.cs
@@ -1,0 +1,63 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using Grpc.Core;
+using NUnit.Framework;
+using Spice.Flight;
+
+namespace SpiceTest;
+
+/// <summary>
+/// Unit tests for how <see cref="SpiceFlightClient"/> describes why a handshake
+/// failed to yield an authorization token.
+/// </summary>
+[TestFixture]
+public class FlightAuthFailureTest
+{
+    [Test]
+    public void NoFailure_ReturnsNoTokenMessage()
+    {
+        var reason = SpiceFlightClient.DescribeAuthFailure(null);
+
+        Assert.That(reason, Is.EqualTo("the runtime returned no authorization token."));
+    }
+
+    [Test]
+    public void RpcFailure_DescribesStatusAndDetail()
+    {
+        var ex = new RpcException(new Status(StatusCode.Unauthenticated, "invalid api key"));
+
+        var reason = SpiceFlightClient.DescribeAuthFailure(ex);
+
+        Assert.That(reason, Is.EqualTo("Unauthenticated - invalid api key."));
+    }
+
+    [Test]
+    public void IncompleteHandshake_ReturnsIncompleteHandshakeMessage()
+    {
+        var ex = new InvalidOperationException("trailers are not available");
+
+        var reason = SpiceFlightClient.DescribeAuthFailure(ex);
+
+        Assert.That(reason, Is.EqualTo("the handshake did not complete before trailers could be read."));
+    }
+}


### PR DESCRIPTION
## This fixes the failing tests

Initially I thought this was only a diagnostics improvement and that CI needed a credential rotation. That was wrong, and the evidence is direct: the TPCH cloud tests **pass on this branch and fail on #22**, same repo, same secrets, same runner.

The credential was never broken. The eager trailer read threw *before* the token in the response headers could be used, so every authenticated connection died regardless of whether the key was valid.

| branch | TestTpchQ1..Q10 | totals |
|---|---|---|
| #22 (without this fix) | `Failed` | 125 passed, **33 failed** |
| #23 (this branch) | `Passed` | 125 passed, **0 failed**, 23 skipped |

The 23 skips are the ADBC-driver tests, which skip for their own unrelated reasons.

## What

`AuthenticateAsync` passed `stream.GetTrailers()` as an argument:

```csharp
var token = GetAuthToken(headers, stream.GetTrailers());
```

Arguments are evaluated eagerly, so the trailers are read before the handshake has completed. gRPC only exposes trailers once a call finishes, so any failing handshake throws:

```
System.InvalidOperationException : Can't get the call trailers because the call has not completed successfully.
   at Spice.Flight.SpiceFlightClient.AuthenticateAsync() ... line 169
```

That exception replaces the gRPC status that says what actually went wrong.

The token is now read from response headers first; trailers are consulted only if the headers carry none, and failing to read them is caught rather than propagated. The resulting `SpiceException` names the likely cause and carries the originating `RpcException` as `InnerException`. Adds an internal `SpiceException` constructor accepting an inner exception.

## Why it matters

This is repo-wide and long-standing, not specific to any branch:

- `trunk`'s own `pr` run has been failing with this exact error since **2026-07-25**
- open PRs #20, #21 and #22 all fail identically — 33 failures each, every one of them this message

Anyone looking at CI right now sees a .NET internal error about trailers and has no way to tell that the cause is a credential. That's what this changes.

## Verification

Reproduced against a TLS endpoint that isn't a Flight service, which produces the same handshake-failure shape as CI:

| | message |
|---|---|
| before | `InvalidOperationException: Can't get the call trailers because the call has not completed successfully.` |
| after | `SpiceException: Failed to authenticate: the runtime returned no authorization token. Check that the API key is valid for this endpoint.` |

Also checked the healthy-server-but-no-token path (valid endpoint, bad key) still fails gracefully with the same clear message rather than regressing.

- [x] `dotnet build -c Release` — all four targets including `netstandard2.0`
- [x] `dotnet test` — 115 passed, 0 failed on net8.0 / net9.0 / net10.0 (33 skipped: the cloud integration tests, which need the API key)
- [x] The cloud integration tests now pass in CI — 0 failures across net8.0 / net9.0 / net10.0

## Follow-on effect

Merging this unblocks #22, whose 11 failing checks are all this same bug.
