### PR TITLE
feat: add `NsqlAsync` and `NsqlGenerateSqlAsync` for the runtime's `/v1/nsql` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,30 @@ matched column values in `Matches`, the row's `PrimaryKey`, the columns requeste
 `AdditionalColumns` in `Data`, and any `Metadata`. The runtime omits the last three when
 empty; they default to empty dictionaries, so they can be read without a null check.
 
+#### NSQL
+
+`NsqlAsync` answers a natural-language question by having the runtime's configured LLM
+generate SQL, then running it. `NsqlGenerateSqlAsync` translates the question into SQL
+without running it. Both require an LLM model configured in the Spicepod.
+
+```csharp
+using Spice;
+using Spice.Nsql;
+
+using var client = new SpiceClientBuilder().Build();
+
+var result = await client.NsqlAsync(new NsqlRequest("top 5 customers by revenue"));
+
+Console.WriteLine(result.SQL);
+foreach (var row in result.Data)
+{
+    Console.WriteLine(row["customer_id"]);
+}
+
+// Or generate the SQL without running it
+var sql = await client.NsqlGenerateSqlAsync(new NsqlRequest("how many orders"));
+```
+
 ### Memory Management
 
 The `SpiceClient` implements `IDisposable` and should be properly disposed to release network resources (gRPC channels, HTTP clients). Use the `using` statement or `using` declaration for automatic disposal:

--- a/Spice/src/Http/ISpiceHttpClient.cs
+++ b/Spice/src/Http/ISpiceHttpClient.cs
@@ -21,6 +21,7 @@ SOFTWARE.
 */
 
 using Spice.Datasets;
+using Spice.Nsql;
 using Spice.Search;
 
 namespace Spice.Http;
@@ -85,4 +86,28 @@ public interface ISpiceHttpClient : IDisposable
     /// <exception cref="System.ArgumentException">Thrown when the search text is null or empty</exception>
     /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
     Task<SearchResponse> SearchAsync(SearchRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Answers a natural-language query by having the runtime's configured LLM generate SQL,
+    /// then running it, via the <c>/v1/nsql</c> endpoint.
+    /// </summary>
+    /// <param name="request">The natural-language query to answer</param>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>The generated SQL alongside the rows it returned</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown when request is null</exception>
+    /// <exception cref="System.ArgumentException">Thrown when the query text is null or empty</exception>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    Task<NsqlResponse> NsqlAsync(NsqlRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Translates a natural-language query into SQL without running it, via the
+    /// <c>/v1/nsql</c> endpoint.
+    /// </summary>
+    /// <param name="request">The natural-language query to translate</param>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>The generated SQL</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown when request is null</exception>
+    /// <exception cref="System.ArgumentException">Thrown when the query text is null or empty</exception>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    Task<string> NsqlGenerateSqlAsync(NsqlRequest request, CancellationToken cancellationToken = default);
 }

--- a/Spice/src/Http/SpiceHttpClient.cs
+++ b/Spice/src/Http/SpiceHttpClient.cs
@@ -26,6 +26,7 @@ using System.Text.Json;
 using Spice.Auth;
 using Spice.Common;
 using Spice.Datasets;
+using Spice.Nsql;
 using Spice.Search;
 
 namespace Spice.Http;
@@ -280,6 +281,102 @@ internal class SpiceHttpClient : ISpiceHttpClient
         }
 
         return JsonSerializer.Deserialize<SearchResponse>(body, SearchJsonOptions) ?? new SearchResponse();
+    }
+
+    /// <summary>
+    /// Asks the runtime for the envelope carrying the generated SQL alongside the results.
+    /// Without it, <c>/v1/nsql</c> returns a bare array of rows and the generated SQL is lost.
+    /// </summary>
+    private const string NsqlJsonMediaType = "application/vnd.spiceai.nsql.v1+json";
+
+    /// <summary>
+    /// Asks the runtime to generate SQL without executing it.
+    /// </summary>
+    private const string NsqlSqlMediaType = "application/sql";
+
+    /// <summary>
+    /// Options used to serialize NSQL requests and deserialize NSQL responses.
+    /// </summary>
+    private static readonly JsonSerializerOptions NsqlJsonOptions = new()
+    {
+        PropertyNamingPolicy = null,
+    };
+
+    /// <summary>
+    /// Answers a natural-language query by having the runtime's configured LLM generate SQL,
+    /// then running it, via the <c>/v1/nsql</c> endpoint.
+    /// </summary>
+    /// <param name="request">The natural-language query to answer</param>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>The generated SQL alongside the rows it returned</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown when request is null</exception>
+    /// <exception cref="System.ArgumentException">Thrown when the query text is null or empty</exception>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    public async Task<NsqlResponse> NsqlAsync(NsqlRequest request, CancellationToken cancellationToken = default)
+    {
+        var body = await DoNsqlRequestAsync(request, NsqlJsonMediaType, cancellationToken).ConfigureAwait(false);
+        return JsonSerializer.Deserialize<NsqlResponse>(body, NsqlJsonOptions) ?? new NsqlResponse();
+    }
+
+    /// <summary>
+    /// Translates a natural-language query into SQL without running it, via the
+    /// <c>/v1/nsql</c> endpoint.
+    /// </summary>
+    /// <param name="request">The natural-language query to translate</param>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>The generated SQL</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown when request is null</exception>
+    /// <exception cref="System.ArgumentException">Thrown when the query text is null or empty</exception>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    public async Task<string> NsqlGenerateSqlAsync(NsqlRequest request, CancellationToken cancellationToken = default)
+    {
+        var body = await DoNsqlRequestAsync(request, NsqlSqlMediaType, cancellationToken).ConfigureAwait(false);
+        return body.Trim();
+    }
+
+    /// <summary>
+    /// Posts <paramref name="request"/> to <c>/v1/nsql</c> asking for <paramref name="accept"/>,
+    /// and returns the response body when the runtime answered with success.
+    /// </summary>
+    private async Task<string> DoNsqlRequestAsync(NsqlRequest request, string accept, CancellationToken cancellationToken)
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Query, $"{nameof(request)}.{nameof(request.Query)}");
+#else
+        if (_disposed) throw new ObjectDisposedException(GetType().FullName);
+        ThrowHelper.ThrowIfNull(request, nameof(request));
+        ThrowHelper.ThrowIfNullOrWhiteSpace(request.Query, $"{nameof(request)}.{nameof(request.Query)}");
+#endif
+
+        var url = $"{_httpAddress}/v1/nsql";
+        var json = JsonSerializer.Serialize(request, NsqlJsonOptions);
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+        httpRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(accept));
+
+        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+
+#if NET8_0_OR_GREATER
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        // netstandard2.0 has no CancellationToken overload for ReadAsStringAsync.
+        var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+
+        if (!response.IsSuccessStatusCode)
+        {
+            // The runtime explains NSQL failures in the body - a missing or ambiguous model,
+            // or SQL that would not run. Surface it rather than only the status code.
+            throw new HttpRequestException(
+                $"NSQL request failed with status {(int)response.StatusCode}: {ExtractErrorMessage(body)}");
+        }
+
+        return body;
     }
 
     /// <summary>

--- a/Spice/src/Nsql/NsqlTypes.cs
+++ b/Spice/src/Nsql/NsqlTypes.cs
@@ -1,0 +1,164 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Spice.Nsql;
+
+/// <summary>
+/// A natural-language query against the runtime's <c>/v1/nsql</c> endpoint.
+/// </summary>
+/// <remarks>
+/// Only <see cref="Query"/> is required. The runtime needs an LLM model configured in the
+/// Spicepod to translate it; when exactly one is configured, <see cref="Model"/> may be left
+/// unset and the runtime selects it.
+/// </remarks>
+public class NsqlRequest
+{
+    /// <summary>
+    /// Creates an NSQL request.
+    /// </summary>
+    /// <param name="query">The question to answer, in natural language</param>
+    public NsqlRequest(string query)
+    {
+        Query = query;
+    }
+
+    /// <summary>
+    /// The question to answer, in natural language. Required.
+    /// </summary>
+    [JsonPropertyName("query")]
+    public string Query { get; set; }
+
+    /// <summary>
+    /// Names the LLM used to generate SQL. When unset, the runtime uses the only compatible
+    /// model configured in the Spicepod, and reports an error if there is not exactly one.
+    /// </summary>
+    [JsonPropertyName("model")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Model { get; set; }
+
+    /// <summary>
+    /// Hints which datasets to sample when building model context. This is a sampling hint
+    /// only - it does not restrict which tables the generated query may reference. When
+    /// unset, all datasets are used.
+    /// </summary>
+    [JsonPropertyName("datasets")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? Datasets { get; set; }
+
+    /// <summary>
+    /// Includes sample rows in the context given to the model. It improves generation on
+    /// ambiguous schemas at the cost of sending data values to the model.
+    /// </summary>
+    [JsonPropertyName("sample_data_enabled")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool SampleDataEnabled { get; set; }
+
+    /// <summary>
+    /// A stable key forwarded to the model provider for prompt caching. Reuse it across
+    /// related requests to benefit from it.
+    /// </summary>
+    [JsonPropertyName("prompt_cache_key")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PromptCacheKey { get; set; }
+}
+
+/// <summary>
+/// Describes one column of an <see cref="NsqlResponse"/>.
+/// </summary>
+public class NsqlField
+{
+    /// <summary>
+    /// The column name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The column's Arrow type in its JSON encoding. Simple types encode as a quoted string
+    /// (<c>"Utf8"</c>, <c>"Int64"</c>); parameterized ones as an object (for example
+    /// <c>{"Timestamp":["Nanosecond",null]}</c>), which is why this is captured as raw JSON
+    /// rather than a fixed shape.
+    /// </summary>
+    [JsonPropertyName("data_type")]
+    public JsonElement DataType { get; set; }
+
+    /// <summary>
+    /// Whether the column admits nulls.
+    /// </summary>
+    [JsonPropertyName("nullable")]
+    public bool Nullable { get; set; }
+}
+
+/// <summary>
+/// The schema of the rows an NSQL call returned.
+/// </summary>
+/// <remarks>
+/// <see cref="Fields"/> is empty when the generated query returned no rows - the runtime
+/// omits the schema body in that case.
+/// </remarks>
+public class NsqlSchema
+{
+    /// <summary>
+    /// The columns of the result, in order.
+    /// </summary>
+    [JsonPropertyName("fields")]
+    public IReadOnlyList<NsqlField> Fields { get; set; } = new List<NsqlField>();
+}
+
+/// <summary>
+/// The result of running a natural-language query via <see cref="SpiceClient.NsqlAsync"/>.
+/// </summary>
+public class NsqlResponse
+{
+    /// <summary>
+    /// The query the model generated. It is worth logging: a surprising result is usually a
+    /// surprising query.
+    /// </summary>
+    [JsonPropertyName("sql")]
+    public string SQL { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The number of rows returned.
+    /// </summary>
+    [JsonPropertyName("row_count")]
+    public int RowCount { get; set; }
+
+    /// <summary>
+    /// Describes the columns in <see cref="Data"/>.
+    /// </summary>
+    [JsonPropertyName("schema")]
+    public NsqlSchema Schema { get; set; } = new();
+
+    /// <summary>
+    /// The rows, each keyed by column name. Values are decoded from JSON, so they carry
+    /// JSON's types rather than the Arrow types named in <see cref="Schema"/> - numbers
+    /// arrive as <see cref="JsonElement"/> holding a number. Use
+    /// <see cref="SpiceClient.NsqlGenerateSqlAsync"/> with <see cref="SpiceClient.Query"/>
+    /// when Arrow-typed results matter.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public IReadOnlyList<IReadOnlyDictionary<string, JsonElement>> Data { get; set; }
+        = new List<IReadOnlyDictionary<string, JsonElement>>();
+}

--- a/Spice/src/SpiceClient.cs
+++ b/Spice/src/SpiceClient.cs
@@ -27,6 +27,7 @@ using Spice.Config;
 using Spice.Datasets;
 using Spice.Flight;
 using Spice.Http;
+using Spice.Nsql;
 using Spice.Search;
 
 namespace Spice;
@@ -296,6 +297,76 @@ public class SpiceClient : IDisposable
         if (HttpClient == null) throw new InvalidOperationException("HttpClient not initialized");
 
         return HttpClient.SearchAsync(request, cancellationToken);
+    }
+
+    /// <summary>
+    /// Answers a natural-language query by having the runtime's configured LLM generate SQL,
+    /// then running it.
+    /// </summary>
+    /// <remarks>
+    /// The generated SQL is returned in <see cref="NsqlResponse.SQL"/>. The runtime executes
+    /// it read-only and retries generation when the query fails to run, so a thrown exception
+    /// means generation or execution failed repeatedly.
+    ///
+    /// <para>
+    /// NSQL requires an LLM model configured in the Spicepod. See
+    /// https://docs.spice.ai/features/text-to-sql for how to configure one.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var result = await client.NsqlAsync(new NsqlRequest("top 5 customers by revenue"));
+    /// Console.WriteLine(result.SQL);
+    /// </code>
+    /// </example>
+    /// <param name="request">The natural-language query to answer</param>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>The generated SQL alongside the rows it returned</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown when request is null</exception>
+    /// <exception cref="System.ArgumentException">Thrown when the query text is null or empty</exception>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    public Task<NsqlResponse> NsqlAsync(NsqlRequest request, CancellationToken cancellationToken = default)
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(_disposed, this);
+#else
+        if (_disposed) throw new ObjectDisposedException(GetType().FullName);
+#endif
+        if (HttpClient == null) throw new InvalidOperationException("HttpClient not initialized");
+
+        return HttpClient.NsqlAsync(request, cancellationToken);
+    }
+
+    /// <summary>
+    /// Translates a natural-language query into SQL without running it.
+    /// </summary>
+    /// <remarks>
+    /// Use it to inspect or edit the query before running it, or to run it through
+    /// <see cref="Query"/> or <see cref="QueryWithParams"/> so the results arrive as Arrow
+    /// rather than decoded JSON.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var sql = await client.NsqlGenerateSqlAsync(new NsqlRequest("how many orders"));
+    /// var result = await client.Query(sql);
+    /// </code>
+    /// </example>
+    /// <param name="request">The natural-language query to translate</param>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>The generated SQL</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown when request is null</exception>
+    /// <exception cref="System.ArgumentException">Thrown when the query text is null or empty</exception>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    public Task<string> NsqlGenerateSqlAsync(NsqlRequest request, CancellationToken cancellationToken = default)
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(_disposed, this);
+#else
+        if (_disposed) throw new ObjectDisposedException(GetType().FullName);
+#endif
+        if (HttpClient == null) throw new InvalidOperationException("HttpClient not initialized");
+
+        return HttpClient.NsqlGenerateSqlAsync(request, cancellationToken);
     }
 
     private bool _disposed;

--- a/SpiceTest/NsqlTest.cs
+++ b/SpiceTest/NsqlTest.cs
@@ -1,0 +1,302 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using Spice;
+using Spice.Nsql;
+
+namespace SpiceTest;
+
+/// <summary>
+/// Covers the wire contract of <c>/v1/nsql</c>: request serialization, response
+/// deserialization, and the HTTP request the client actually puts on the wire, using a
+/// loopback <see cref="HttpListener"/> as a stand-in runtime. No Spice runtime or network
+/// access is required.
+/// </summary>
+public class NsqlTest
+{
+    // ==================== Request serialization ====================
+
+    private static string Serialize(NsqlRequest request) => JsonSerializer.Serialize(request);
+
+    [Test]
+    public void Test_Request_QueryOnly_OmitsOptionalFields()
+    {
+        var json = Serialize(new NsqlRequest("top 5 customers by revenue"));
+
+        Assert.That(json, Is.EqualTo("{\"query\":\"top 5 customers by revenue\"}"));
+    }
+
+    [Test]
+    public void Test_Request_AllOptions_UseWireNames()
+    {
+        var request = new NsqlRequest("top 5 customers by revenue")
+        {
+            Model = "nsql-model",
+            Datasets = new[] { "sales" },
+            SampleDataEnabled = true,
+            PromptCacheKey = "sales-dashboard",
+        };
+
+        using var document = JsonDocument.Parse(Serialize(request));
+        var root = document.RootElement;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(root.GetProperty("query").GetString(), Is.EqualTo("top 5 customers by revenue"));
+            Assert.That(root.GetProperty("model").GetString(), Is.EqualTo("nsql-model"));
+            Assert.That(root.GetProperty("datasets").GetArrayLength(), Is.EqualTo(1));
+            Assert.That(root.GetProperty("sample_data_enabled").GetBoolean(), Is.True);
+            Assert.That(root.GetProperty("prompt_cache_key").GetString(), Is.EqualTo("sales-dashboard"));
+        });
+    }
+
+    [Test]
+    public void Test_Request_FalseSampling_IsOmitted()
+    {
+        // sample_data_enabled defaults to false server-side, so omitting it rather than
+        // sending false keeps the body minimal.
+        var json = Serialize(new NsqlRequest("how many orders") { SampleDataEnabled = false });
+
+        Assert.That(json, Does.Not.Contain("sample_data_enabled"));
+    }
+
+    [Test]
+    public void Test_Request_EmptyDatasets_IsSentNotDropped()
+    {
+        // Empty is a real value the caller supplied, distinct from unset - matches how
+        // SearchRequest treats empty collections.
+        var json = Serialize(new NsqlRequest("how many orders") { Datasets = Array.Empty<string>() });
+
+        Assert.That(json, Does.Contain("\"datasets\":[]"));
+    }
+
+    // ==================== Response deserialization ====================
+
+    private static NsqlResponse Deserialize(string json) =>
+        JsonSerializer.Deserialize<NsqlResponse>(json)!;
+
+    [Test]
+    public void Test_Response_DeserializesWireFormat()
+    {
+        const string body = """
+        {
+            "row_count": 2,
+            "schema": {
+                "fields": [
+                    {"name": "customer_id", "data_type": "Utf8", "nullable": false},
+                    {"name": "ts", "data_type": {"Timestamp": ["Nanosecond", null]}, "nullable": true}
+                ]
+            },
+            "data": [
+                {"customer_id": "12345", "ts": 1724716542},
+                {"customer_id": "67890", "ts": 1724716543}
+            ],
+            "sql": "SELECT customer_id, ts FROM sales LIMIT 2"
+        }
+        """;
+
+        var response = Deserialize(body);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.SQL, Is.EqualTo("SELECT customer_id, ts FROM sales LIMIT 2"));
+            Assert.That(response.RowCount, Is.EqualTo(2));
+            Assert.That(response.Data, Has.Count.EqualTo(2));
+            Assert.That(response.Data[0]["customer_id"].GetString(), Is.EqualTo("12345"));
+            Assert.That(response.Schema.Fields, Has.Count.EqualTo(2));
+            Assert.That(response.Schema.Fields[0].Name, Is.EqualTo("customer_id"));
+            // A simple Arrow type encodes as a quoted string, a parameterized one as an
+            // object - which is why DataType stays raw JSON.
+            Assert.That(response.Schema.Fields[0].DataType.GetString(), Is.EqualTo("Utf8"));
+            Assert.That(response.Schema.Fields[1].DataType.ValueKind, Is.EqualTo(JsonValueKind.Object));
+            Assert.That(response.Schema.Fields[1].Nullable, Is.True);
+        });
+    }
+
+    [Test]
+    public void Test_Response_EmptySchema_YieldsEmptyFieldsNotNull()
+    {
+        // The runtime serializes schema as {} when the generated query returned no rows, so
+        // decoding must not depend on a fields key being present.
+        var response = Deserialize("""{"row_count":0,"schema":{},"data":[],"sql":"SELECT 1 WHERE false"}""");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.RowCount, Is.EqualTo(0));
+            Assert.That(response.Schema.Fields, Is.Not.Null.And.Empty);
+            Assert.That(response.SQL, Is.EqualTo("SELECT 1 WHERE false"));
+        });
+    }
+
+    // ==================== HTTP request/response wiring ====================
+
+    private sealed record CapturedRequest(string HttpMethod, string Path, string? Accept, string Body);
+
+    /// <summary>
+    /// Runs <paramref name="action"/> against a loopback listener and returns the single
+    /// request it received. The listener answers with <paramref name="responseBody"/> at
+    /// <paramref name="statusCode"/>.
+    /// </summary>
+    private static async Task<CapturedRequest> CaptureAsync(
+        Func<SpiceClient, Task> action, HttpStatusCode statusCode = HttpStatusCode.OK, string responseBody = "")
+    {
+        var port = GetFreePort();
+        using var listener = new HttpListener();
+        listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+        listener.Start();
+
+        var serverTask = Task.Run(async () =>
+        {
+            var context = await listener.GetContextAsync().ConfigureAwait(false);
+            using var reader = new StreamReader(context.Request.InputStream, Encoding.UTF8);
+            var body = await reader.ReadToEndAsync().ConfigureAwait(false);
+
+            var captured = new CapturedRequest(
+                context.Request.HttpMethod,
+                context.Request.Url!.AbsolutePath,
+                context.Request.Headers["Accept"],
+                body);
+
+            context.Response.StatusCode = (int)statusCode;
+            var payload = Encoding.UTF8.GetBytes(responseBody);
+            context.Response.ContentLength64 = payload.Length;
+            await context.Response.OutputStream.WriteAsync(payload).ConfigureAwait(false);
+            context.Response.Close();
+            return captured;
+        });
+
+        using (var client = new SpiceClientBuilder()
+                   .WithHttpAddress($"http://127.0.0.1:{port}")
+                   .Build())
+        {
+            await action(client).ConfigureAwait(false);
+        }
+
+        return await serverTask.ConfigureAwait(false);
+    }
+
+    private static int GetFreePort()
+    {
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+        return port;
+    }
+
+    private static readonly string EmptyNsqlResponseBody =
+        """{"row_count":0,"schema":{},"data":[],"sql":"SELECT 1"}""";
+
+    [Test]
+    public async Task Test_NsqlAsync_PostsToNsqlEndpoint_WithJsonEnvelopeAccept()
+    {
+        var request = await CaptureAsync(
+            client => client.NsqlAsync(new NsqlRequest("how many orders")),
+            responseBody: EmptyNsqlResponseBody);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(request.HttpMethod, Is.EqualTo("POST"));
+            Assert.That(request.Path, Is.EqualTo("/v1/nsql"));
+            Assert.That(request.Accept, Is.EqualTo("application/vnd.spiceai.nsql.v1+json"));
+        });
+    }
+
+    [Test]
+    public async Task Test_NsqlGenerateSqlAsync_PostsToNsqlEndpoint_WithSqlAccept()
+    {
+        var request = await CaptureAsync(
+            client => client.NsqlGenerateSqlAsync(new NsqlRequest("how many orders")),
+            responseBody: "SELECT count(*) FROM orders");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(request.HttpMethod, Is.EqualTo("POST"));
+            Assert.That(request.Path, Is.EqualTo("/v1/nsql"));
+            Assert.That(request.Accept, Is.EqualTo("application/sql"));
+        });
+    }
+
+    [Test]
+    public async Task Test_NsqlGenerateSqlAsync_TrimsRuntimeWhitespace()
+    {
+        string? sql = null;
+        await CaptureAsync(
+            async client => sql = await client.NsqlGenerateSqlAsync(new NsqlRequest("how many orders")),
+            responseBody: "\n  SELECT count(*) FROM orders\n");
+
+        Assert.That(sql, Is.EqualTo("SELECT count(*) FROM orders"));
+    }
+
+    // A missing or ambiguous model is the most common NSQL failure and the runtime explains
+    // it in the body. Losing that leaves the caller with a bare status code.
+    [Test]
+    public void Test_NsqlAsync_ErrorSurfacesResponseBody()
+    {
+        var ex = Assert.ThrowsAsync<HttpRequestException>(async () => await CaptureAsync(
+            client => client.NsqlAsync(new NsqlRequest("how many orders")),
+            statusCode: HttpStatusCode.BadRequest,
+            responseBody: "No model specified and no compatible LLM model is configured."));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex!.Message, Does.Contain("No model specified"));
+            Assert.That(ex.Message, Does.Contain("400"));
+        });
+    }
+
+    [Test]
+    public void Test_NsqlAsync_NullRequest_Throws()
+    {
+        using var client = new SpiceClientBuilder().Build();
+
+        Assert.ThrowsAsync<ArgumentNullException>(async () => await client.NsqlAsync(null!));
+    }
+
+    [Test]
+    public void Test_NsqlAsync_BlankQuery_Throws()
+    {
+        using var client = new SpiceClientBuilder().Build();
+
+        Assert.ThrowsAsync<ArgumentException>(async () => await client.NsqlAsync(new NsqlRequest("  ")));
+    }
+
+    [Test]
+    public void Test_NsqlGenerateSqlAsync_NullRequest_Throws()
+    {
+        using var client = new SpiceClientBuilder().Build();
+
+        Assert.ThrowsAsync<ArgumentNullException>(async () => await client.NsqlGenerateSqlAsync(null!));
+    }
+
+    [Test]
+    public void Test_NsqlGenerateSqlAsync_BlankQuery_Throws()
+    {
+        using var client = new SpiceClientBuilder().Build();
+
+        Assert.ThrowsAsync<ArgumentException>(async () => await client.NsqlGenerateSqlAsync(new NsqlRequest("  ")));
+    }
+}


### PR DESCRIPTION
## What

Adds `SpiceClient.NsqlAsync` and `NsqlGenerateSqlAsync`, wrapping the runtime's `POST /v1/nsql` endpoint (natural-language to SQL).

- `NsqlAsync` generates SQL from a natural-language query and runs it, returning the SQL alongside the rows.
- `NsqlGenerateSqlAsync` only translates, so the caller can inspect/edit the SQL or run it themselves via `Query`.

## Why

gospice already exposes this (`Nsql` / `NsqlGenerateSQL`); this brings the .NET SDK in line with the other SDKs.

## Testing

New `NsqlTest.cs`: wire-contract tests for request/response JSON shape, and loopback-`HttpListener` tests asserting the actual HTTP request (path, `Accept` header per method, error body surfacing). `dotnet build`/`dotnet test` pass on netstandard2.0/net8.0/net9.0 (no net10 SDK available locally).