### PR TITLE
feat: add ListActiveQueriesAsync and CancelActiveQueryAsync

### DIFF
--- a/Spice/src/Http/ISpiceHttpClient.cs
+++ b/Spice/src/Http/ISpiceHttpClient.cs
@@ -21,6 +21,7 @@ SOFTWARE.
 */
 
 using Spice.Datasets;
+using Spice.Query;
 using Spice.Search;
 
 namespace Spice.Http;
@@ -85,4 +86,22 @@ public interface ISpiceHttpClient : IDisposable
     /// <exception cref="System.ArgumentException">Thrown when the search text is null or empty</exception>
     /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
     Task<SearchResponse> SearchAsync(SearchRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists the synchronous queries currently running, by calling <c>GET /v1/sql/active</c>.
+    /// </summary>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>The running queries, empty when none are running</returns>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    Task<IReadOnlyList<ActiveQuery>> ListActiveQueriesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Cancels a running synchronous query by ID, by calling <c>POST /v1/sql/{id}/cancel</c>.
+    /// </summary>
+    /// <param name="queryId">The query ID, from <see cref="ListActiveQueriesAsync"/></param>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>A task representing the asynchronous operation</returns>
+    /// <exception cref="System.ArgumentException">Thrown when queryId is null, empty, or not a valid UUID</exception>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    Task CancelActiveQueryAsync(string queryId, CancellationToken cancellationToken = default);
 }

--- a/Spice/src/Http/SpiceHttpClient.cs
+++ b/Spice/src/Http/SpiceHttpClient.cs
@@ -26,6 +26,7 @@ using System.Text.Json;
 using Spice.Auth;
 using Spice.Common;
 using Spice.Datasets;
+using Spice.Query;
 using Spice.Search;
 
 namespace Spice.Http;
@@ -281,6 +282,111 @@ internal class SpiceHttpClient : ISpiceHttpClient
 
         return JsonSerializer.Deserialize<SearchResponse>(body, SearchJsonOptions) ?? new SearchResponse();
     }
+
+    /// <summary>
+    /// Lists the synchronous queries currently running, by calling <c>GET /v1/sql/active</c>.
+    /// </summary>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>The running queries, empty when none are running</returns>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    public async Task<IReadOnlyList<ActiveQuery>> ListActiveQueriesAsync(CancellationToken cancellationToken = default)
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(_disposed, this);
+#else
+        if (_disposed) throw new ObjectDisposedException(GetType().FullName);
+#endif
+
+        var url = $"{_httpAddress}/v1/sql/active";
+        using var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+
+#if NET8_0_OR_GREATER
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+
+        if (response.StatusCode == System.Net.HttpStatusCode.Forbidden)
+        {
+            throw new HttpRequestException(
+                "Listing active queries failed: the configured API key does not allow listing queries, use a key with write access.");
+        }
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException(
+                $"GET {url} failed with status {(int)response.StatusCode} ({response.StatusCode}): {ExtractErrorMessage(body)}");
+        }
+
+        var decoded = JsonSerializer.Deserialize<ActiveQueriesResponse>(body);
+        return decoded?.Queries ?? new List<ActiveQuery>();
+    }
+
+    /// <summary>
+    /// Cancels a running synchronous query by ID, by calling <c>POST /v1/sql/{id}/cancel</c>.
+    /// </summary>
+    /// <param name="queryId">The query ID, from <see cref="ListActiveQueriesAsync"/></param>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>A task representing the asynchronous operation</returns>
+    /// <exception cref="System.ArgumentException">Thrown when queryId is null, empty, or not a valid UUID</exception>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    public async Task CancelActiveQueryAsync(string queryId, CancellationToken cancellationToken = default)
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentException.ThrowIfNullOrWhiteSpace(queryId);
+#else
+        if (_disposed) throw new ObjectDisposedException(GetType().FullName);
+        ThrowHelper.ThrowIfNullOrWhiteSpace(queryId, nameof(queryId));
+#endif
+
+        // queryId is caller input that reaches the runtime as a URL path segment. Reject
+        // anything that is not a canonical UUID here, rather than building a path from it:
+        // a value like "." or ".." is unreserved and survives escaping, so a proxy or server
+        // that resolves dot segments could route this POST somewhere the caller never named.
+        if (!IsValidQueryId(queryId))
+        {
+            throw new ArgumentException(
+                $"Query ID \"{queryId}\" is not a valid UUID. Use the QueryId from {nameof(ListActiveQueriesAsync)}.",
+                nameof(queryId));
+        }
+
+        var url = $"{_httpAddress}/v1/sql/{Uri.EscapeDataString(queryId)}/cancel";
+        using var response = await _httpClient.PostAsync(url, content: null, cancellationToken).ConfigureAwait(false);
+
+#if NET8_0_OR_GREATER
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+
+        switch (response.StatusCode)
+        {
+            case System.Net.HttpStatusCode.OK:
+                return;
+            case System.Net.HttpStatusCode.BadRequest:
+                throw new ArgumentException(
+                    $"Query ID \"{queryId}\" is not a valid UUID. Use the QueryId from {nameof(ListActiveQueriesAsync)}.",
+                    nameof(queryId));
+            case System.Net.HttpStatusCode.Forbidden:
+                throw new HttpRequestException(
+                    "Cancelling the query failed: the configured API key does not allow cancelling queries, use a key with write access.");
+            case System.Net.HttpStatusCode.NotFound:
+                throw new HttpRequestException(
+                    $"No active query \"{queryId}\" found: it may have already finished, or it was submitted under a different API key.");
+            default:
+                throw new HttpRequestException(
+                    $"POST {url} failed with status {(int)response.StatusCode} ({response.StatusCode}): {ExtractErrorMessage(body)}");
+        }
+    }
+
+    /// <summary>
+    /// Reports whether queryId has the exact canonical hyphenated shape the runtime parses
+    /// as a UUID (36 characters, lowercase or uppercase hex, no surrounding whitespace or
+    /// braces) — the IDs this SDK cancels always come from <see cref="ListActiveQueriesAsync"/>,
+    /// so anything looser cannot name a running query.
+    /// </summary>
+    private static bool IsValidQueryId(string queryId) =>
+        queryId.Length == 36 && Guid.TryParseExact(queryId, "D", out _);
 
     /// <summary>
     /// Pulls the runtime's error message out of a failed response body, falling back to

--- a/Spice/src/Query/ActiveQuery.cs
+++ b/Spice/src/Query/ActiveQuery.cs
@@ -1,0 +1,93 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json.Serialization;
+
+namespace Spice.Query;
+
+/// <summary>
+/// A synchronous query currently running on the Spice runtime.
+/// </summary>
+/// <remarks>
+/// Synchronous queries are the ones started by <see cref="SpiceClient.Query"/>,
+/// <see cref="SpiceClient.QueryWithParams"/>, FlightSQL, NSQL, and search. The runtime does not
+/// return a query's ID to the client that submitted it, so <see cref="SpiceClient.ListActiveQueriesAsync"/>
+/// is how to find the ID that <see cref="SpiceClient.CancelActiveQueryAsync"/> needs.
+/// </remarks>
+public class ActiveQuery
+{
+    /// <summary>
+    /// The ID the runtime assigned to this query. Pass this to
+    /// <see cref="SpiceClient.CancelActiveQueryAsync"/> to cancel it.
+    /// </summary>
+    [JsonPropertyName("query_id")]
+    public string QueryId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The protocol the query arrived on: <c>"http"</c>, <c>"flight"</c>, <c>"flightsql"</c>, or
+    /// <c>"internal"</c>.
+    /// </summary>
+    [JsonPropertyName("protocol")]
+    public string Protocol { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The query's SQL, truncated by the runtime for display.
+    /// </summary>
+    [JsonPropertyName("sql_preview")]
+    public string SqlPreview { get; set; } = string.Empty;
+
+    /// <summary>
+    /// When the query started, in milliseconds since the Unix epoch.
+    /// </summary>
+    [JsonPropertyName("started_at_ms")]
+    public long StartedAtMs { get; set; }
+
+    /// <summary>
+    /// The query's start time.
+    /// </summary>
+    [JsonIgnore]
+    public DateTimeOffset StartedAt => DateTimeOffset.FromUnixTimeMilliseconds(StartedAtMs);
+}
+
+/// <summary>
+/// The wire envelope returned by <c>GET /v1/sql/active</c>.
+/// </summary>
+internal sealed class ActiveQueriesResponse
+{
+    [JsonPropertyName("queries")]
+    public List<ActiveQuery> Queries { get; set; } = new();
+
+    [JsonPropertyName("total_count")]
+    public int TotalCount { get; set; }
+}
+
+/// <summary>
+/// The wire envelope returned by <c>POST /v1/sql/{id}/cancel</c>.
+/// </summary>
+internal sealed class CancelActiveQueryResponse
+{
+    [JsonPropertyName("query_id")]
+    public string QueryId { get; set; } = string.Empty;
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
+}

--- a/Spice/src/SpiceClient.cs
+++ b/Spice/src/SpiceClient.cs
@@ -27,6 +27,7 @@ using Spice.Config;
 using Spice.Datasets;
 using Spice.Flight;
 using Spice.Http;
+using Spice.Query;
 using Spice.Search;
 
 namespace Spice;
@@ -296,6 +297,72 @@ public class SpiceClient : IDisposable
         if (HttpClient == null) throw new InvalidOperationException("HttpClient not initialized");
 
         return HttpClient.SearchAsync(request, cancellationToken);
+    }
+
+    /// <summary>
+    /// Lists the synchronous queries currently running on the runtime.
+    /// </summary>
+    /// <remarks>
+    /// Synchronous queries are the ones started by <see cref="Query"/>, <see cref="QueryWithParams"/>,
+    /// FlightSQL, NSQL, and search. The runtime does not return a query's ID to the client that
+    /// submitted it, so this is how to find the ID that <see cref="CancelActiveQueryAsync"/> needs.
+    ///
+    /// <para>
+    /// Results are scoped to the authenticated principal — an API key or a client certificate —
+    /// rather than to this <see cref="SpiceClient"/> instance: every client presenting the same
+    /// credential lists the same queries. Runtime releases up to and including v2.1.5 do not scope
+    /// these endpoints at all; see
+    /// <see href="https://github.com/spiceai/spiceai/pull/12841">spiceai/spiceai#12841</see>.
+    /// </para>
+    ///
+    /// <para>
+    /// Results also cover only the one runtime instance this client's HTTP endpoint reaches, since
+    /// the runtime holds active queries in memory per process.
+    /// </para>
+    /// </remarks>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>The running queries, empty when none are running</returns>
+    /// <exception cref="System.InvalidOperationException">Thrown when the client is not initialized</exception>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    public Task<IReadOnlyList<ActiveQuery>> ListActiveQueriesAsync(CancellationToken cancellationToken = default)
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(_disposed, this);
+#else
+        if (_disposed) throw new ObjectDisposedException(GetType().FullName);
+#endif
+        if (HttpClient == null) throw new InvalidOperationException("HttpClient not initialized");
+
+        return HttpClient.ListActiveQueriesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Cancels a running synchronous query by ID.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="queryId"/> comes from <see cref="ListActiveQueriesAsync"/>. Cancellation is
+    /// scoped to the authenticated principal, not to this <see cref="SpiceClient"/> instance: any
+    /// client presenting the same credential can cancel the query, while an ID outside that scope is
+    /// reported as not found. This reaches the one runtime instance this client's HTTP endpoint
+    /// resolves to, with the same runtime-version scoping caveat described on
+    /// <see cref="ListActiveQueriesAsync"/>.
+    /// </remarks>
+    /// <param name="queryId">The query ID, from <see cref="ListActiveQueriesAsync"/></param>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>A task representing the asynchronous operation</returns>
+    /// <exception cref="System.ArgumentException">Thrown when queryId is null, empty, or not a valid UUID</exception>
+    /// <exception cref="System.InvalidOperationException">Thrown when the client is not initialized</exception>
+    /// <exception cref="System.Net.Http.HttpRequestException">Thrown when the HTTP request fails</exception>
+    public Task CancelActiveQueryAsync(string queryId, CancellationToken cancellationToken = default)
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(_disposed, this);
+#else
+        if (_disposed) throw new ObjectDisposedException(GetType().FullName);
+#endif
+        if (HttpClient == null) throw new InvalidOperationException("HttpClient not initialized");
+
+        return HttpClient.CancelActiveQueryAsync(queryId, cancellationToken);
     }
 
     private bool _disposed;

--- a/SpiceTest/ActiveQueriesTest.cs
+++ b/SpiceTest/ActiveQueriesTest.cs
@@ -1,0 +1,306 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Spice;
+using Spice.Query;
+
+namespace SpiceTest;
+
+/// <summary>
+/// Covers <see cref="SpiceClient.ListActiveQueriesAsync"/> and
+/// <see cref="SpiceClient.CancelActiveQueryAsync"/> against a stub HTTP endpoint, so the behaviour
+/// is verified without a live Spice runtime.
+/// </summary>
+public class ActiveQueriesTest
+{
+    private const string ValidQueryId = "0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70";
+
+    // ==================== ListActiveQueriesAsync ====================
+
+    [Test]
+    public async Task Test_ListActiveQueries_ReturnsQueries_WhenRuntimeReportsThem()
+    {
+        var body = """
+        {"queries":[
+            {"query_id":"0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70","protocol":"flight","sql_preview":"SELECT * FROM taxi_trips","started_at_ms":1750000000000},
+            {"query_id":"0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f71","protocol":"http","sql_preview":"SELECT 1","started_at_ms":1750000000500}
+        ],"total_count":2}
+        """;
+        using var runtime = new StubRuntime((_, _) => (HttpStatusCode.OK, body));
+        using var client = new SpiceClientBuilder().WithHttpAddress(runtime.Address).Build();
+
+        var queries = await client.ListActiveQueriesAsync();
+
+        Assert.That(runtime.RequestedPaths, Does.Contain("/v1/sql/active"));
+        Assert.That(runtime.RequestedMethods, Does.Contain("GET"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(queries, Has.Count.EqualTo(2));
+            Assert.That(queries[0].QueryId, Is.EqualTo("0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70"));
+            Assert.That(queries[0].Protocol, Is.EqualTo("flight"));
+            Assert.That(queries[0].SqlPreview, Is.EqualTo("SELECT * FROM taxi_trips"));
+            Assert.That(queries[0].StartedAtMs, Is.EqualTo(1750000000000));
+            Assert.That(queries[1].Protocol, Is.EqualTo("http"));
+        });
+    }
+
+    [Test]
+    public async Task Test_ListActiveQueries_ReturnsEmptyList_WhenNoneRunning()
+    {
+        using var runtime = new StubRuntime((_, _) => (HttpStatusCode.OK, """{"queries":[],"total_count":0}"""));
+        using var client = new SpiceClientBuilder().WithHttpAddress(runtime.Address).Build();
+
+        var queries = await client.ListActiveQueriesAsync();
+
+        Assert.That(queries, Is.Not.Null.And.Empty);
+    }
+
+    [Test]
+    public void Test_ListActiveQueries_Throws_WhenForbidden()
+    {
+        using var runtime = new StubRuntime((_, _) => (HttpStatusCode.Forbidden, "write access required"));
+        using var client = new SpiceClientBuilder().WithHttpAddress(runtime.Address).Build();
+
+        var ex = Assert.ThrowsAsync<HttpRequestException>(async () => await client.ListActiveQueriesAsync());
+        Assert.That(ex!.Message, Does.Contain("write access"));
+    }
+
+    [Test]
+    public void Test_ListActiveQueries_Throws_NamingStatus_OnServerError()
+    {
+        using var runtime = new StubRuntime((_, _) => (HttpStatusCode.InternalServerError, "boom"));
+        using var client = new SpiceClientBuilder().WithHttpAddress(runtime.Address).Build();
+
+        var ex = Assert.ThrowsAsync<HttpRequestException>(async () => await client.ListActiveQueriesAsync());
+        Assert.That(ex!.Message, Does.Contain("500"));
+    }
+
+    // ==================== CancelActiveQueryAsync ====================
+
+    [Test]
+    public async Task Test_CancelActiveQuery_Succeeds()
+    {
+        using var runtime = new StubRuntime((_, _) =>
+            (HttpStatusCode.OK, $$"""{"query_id":"{{ValidQueryId}}","status":"cancelled"}"""));
+        using var client = new SpiceClientBuilder().WithHttpAddress(runtime.Address).Build();
+
+        await client.CancelActiveQueryAsync(ValidQueryId);
+
+        Assert.That(runtime.RequestedPaths, Does.Contain($"/v1/sql/{ValidQueryId}/cancel"));
+        Assert.That(runtime.RequestedMethods, Does.Contain("POST"));
+    }
+
+    [Test]
+    public void Test_CancelActiveQuery_Throws_WhenQueryIdIsBlank_WithoutSendingARequest()
+    {
+        using var runtime = new StubRuntime((_, _) => (HttpStatusCode.OK, "{}"));
+        using var client = new SpiceClientBuilder().WithHttpAddress(runtime.Address).Build();
+
+        Assert.ThrowsAsync<ArgumentException>(async () => await client.CancelActiveQueryAsync(""));
+        Assert.ThrowsAsync<ArgumentException>(async () => await client.CancelActiveQueryAsync("   "));
+        Assert.That(runtime.RequestedPaths, Is.Empty);
+    }
+
+    // An ID that is not a UUID must never become a request path: "." and ".." are unreserved, so
+    // escaping leaves them intact, and a proxy or server that resolves dot segments would route
+    // this POST off the cancel route entirely.
+    [TestCase(".")]
+    [TestCase("..")]
+    [TestCase("../queries/escape")]
+    [TestCase("not-a-uuid")]
+    [TestCase("0198f0a1-9c3d-7c4e-8a11")]
+    [TestCase("0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f7g")]
+    [TestCase("0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70/cancel")]
+    [TestCase("{0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70}")]
+    [TestCase(" 0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70")]
+    public void Test_CancelActiveQuery_RejectsNonUuidQueryId_WithoutSendingARequest(string queryId)
+    {
+        using var runtime = new StubRuntime((_, _) => (HttpStatusCode.OK, "{}"));
+        using var client = new SpiceClientBuilder().WithHttpAddress(runtime.Address).Build();
+
+        var ex = Assert.ThrowsAsync<ArgumentException>(async () => await client.CancelActiveQueryAsync(queryId));
+
+        Assert.That(ex!.Message, Does.Contain("not a valid UUID"));
+        Assert.That(runtime.RequestedPaths, Is.Empty, "an invalid query ID reached the runtime");
+    }
+
+    [Test]
+    public void Test_CancelActiveQuery_AcceptsUppercaseUuid()
+    {
+        using var runtime = new StubRuntime((_, _) => (HttpStatusCode.OK, "{}"));
+        using var client = new SpiceClientBuilder().WithHttpAddress(runtime.Address).Build();
+
+        Assert.DoesNotThrowAsync(async () => await client.CancelActiveQueryAsync(ValidQueryId.ToUpperInvariant()));
+    }
+
+    [Test]
+    public void Test_CancelActiveQuery_Throws_WhenNotFound()
+    {
+        using var runtime = new StubRuntime((_, _) => (HttpStatusCode.NotFound, """{"error":"not found"}"""));
+        using var client = new SpiceClientBuilder().WithHttpAddress(runtime.Address).Build();
+
+        var ex = Assert.ThrowsAsync<HttpRequestException>(async () => await client.CancelActiveQueryAsync(ValidQueryId));
+        Assert.That(ex!.Message, Does.Contain("already finished"));
+    }
+
+    [Test]
+    public void Test_CancelActiveQuery_Throws_WhenRuntimeReturnsBadRequest()
+    {
+        using var runtime = new StubRuntime((_, _) => (HttpStatusCode.BadRequest, """{"error":"Invalid query_id"}"""));
+        using var client = new SpiceClientBuilder().WithHttpAddress(runtime.Address).Build();
+
+        var ex = Assert.ThrowsAsync<ArgumentException>(async () => await client.CancelActiveQueryAsync(ValidQueryId));
+        Assert.That(ex!.Message, Does.Contain("not a valid UUID"));
+    }
+
+    [Test]
+    public void Test_CancelActiveQuery_Throws_WhenForbidden()
+    {
+        using var runtime = new StubRuntime((_, _) => (HttpStatusCode.Forbidden, "write access required"));
+        using var client = new SpiceClientBuilder().WithHttpAddress(runtime.Address).Build();
+
+        var ex = Assert.ThrowsAsync<HttpRequestException>(async () => await client.CancelActiveQueryAsync(ValidQueryId));
+        Assert.That(ex!.Message, Does.Contain("write access"));
+    }
+
+    [Test]
+    public void Test_CancelActiveQuery_Throws_NamingStatus_OnServerError()
+    {
+        using var runtime = new StubRuntime((_, _) => (HttpStatusCode.InternalServerError, "boom"));
+        using var client = new SpiceClientBuilder().WithHttpAddress(runtime.Address).Build();
+
+        var ex = Assert.ThrowsAsync<HttpRequestException>(async () => await client.CancelActiveQueryAsync(ValidQueryId));
+        Assert.That(ex!.Message, Does.Contain("500"));
+    }
+
+    // ==================== ActiveQuery.StartedAt ====================
+
+    [Test]
+    public void Test_ActiveQuery_StartedAt_ConvertsFromUnixMillis()
+    {
+        var query = new ActiveQuery { StartedAtMs = 1750000000000 };
+
+        Assert.That(query.StartedAt, Is.EqualTo(DateTimeOffset.FromUnixTimeMilliseconds(1750000000000)));
+    }
+
+    /// <summary>
+    /// Minimal loopback HTTP endpoint that answers every request with a caller-supplied status and
+    /// body, and records the paths/methods it was asked for.
+    /// </summary>
+    private sealed class StubRuntime : IDisposable
+    {
+        private readonly HttpListener _listener;
+        private readonly ConcurrentQueue<string> _paths = new();
+        private readonly ConcurrentQueue<string> _methods = new();
+        private bool _disposed;
+
+        public string Address { get; }
+
+        public IEnumerable<string> RequestedPaths => _paths;
+
+        public IEnumerable<string> RequestedMethods => _methods;
+
+        public StubRuntime(Func<string, string, (HttpStatusCode Status, string Body)> respond)
+        {
+            var port = ReserveFreePort();
+            Address = $"http://localhost:{port}";
+
+            _listener = new HttpListener();
+            _listener.Prefixes.Add($"{Address}/");
+            _listener.Start();
+
+            _ = Task.Run(async () =>
+            {
+                while (_listener.IsListening)
+                {
+                    HttpListenerContext context;
+                    try
+                    {
+                        context = await _listener.GetContextAsync().ConfigureAwait(false);
+                    }
+                    catch (HttpListenerException)
+                    {
+                        return; // Listener stopped.
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        return;
+                    }
+
+                    try
+                    {
+                        var path = context.Request.Url?.AbsolutePath ?? string.Empty;
+                        var method = context.Request.HttpMethod;
+                        _paths.Enqueue(path);
+                        _methods.Enqueue(method);
+
+                        var (status, body) = respond(path, method);
+                        var payload = Encoding.UTF8.GetBytes(body);
+                        context.Response.StatusCode = (int)status;
+                        context.Response.ContentType = "application/json";
+                        context.Response.ContentLength64 = payload.Length;
+                        await context.Response.OutputStream.WriteAsync(payload.AsMemory()).ConfigureAwait(false);
+                    }
+                    catch (Exception)
+                    {
+                        // The client may have disconnected, or the listener may be disposing
+                        // concurrently with this response - either way there's no caller left
+                        // to report a test failure to.
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            context.Response.Close();
+                        }
+                        catch (Exception)
+                        {
+                            // Same rationale as above.
+                        }
+                    }
+                }
+            });
+        }
+
+        public static int ReserveFreePort()
+        {
+            var probe = new TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+            return port;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            _listener.Stop();
+            _listener.Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SpiceClient.ListActiveQueriesAsync()` (`GET /v1/sql/active`) and `SpiceClient.CancelActiveQueryAsync(queryId)` (`POST /v1/sql/{id}/cancel`), matching support already shipped in the gospice SDK.
- Since the runtime doesn't hand a submitted query its own ID, `ListActiveQueriesAsync` is how a caller discovers the ID that `CancelActiveQueryAsync` needs.
- Query IDs are validated as canonical UUIDs client-side before being placed in a URL path, so malformed input never reaches the runtime.

## Test plan

- New unit tests in `SpiceTest/ActiveQueriesTest.cs` against a loopback stub HTTP server (no live runtime required) covering success, empty-list, permission/not-found/status-code error paths, and UUID validation edge cases.
- `dotnet build`/`dotnet test` pass locally for net8.0/net9.0/netstandard2.0 (net10.0 not buildable in this sandbox, no SDK installed; unaffected by this change).