### PR TITLE
feat!: async query submission over Flight DoAction, rename sync Query/QueryWithParams to Sql/SqlWithParamsAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,41 +27,23 @@ using Spice;
 using var client = new SpiceClientBuilder().Build();
 ```
 
-#### Query
+#### Sql
+
+`SqlAsync` runs a query against the Flight endpoint and streams the results back synchronously:
 
 ```csharp
 using Spice;
 
 using var client = new SpiceClientBuilder().Build();
 
-var data = await client.Query("SELECT * FROM my_table LIMIT 10;");
-```
-
-#### Parameterized Queries
-
-Use parameterized queries to prevent SQL injection and improve performance:
-
-```csharp
-using Spice;
-
-using var client = new SpiceClientBuilder().Build();
-
-var parameters = new Dictionary<string, object>
-{
-    { "product_id", 42 },
-    { "min_price", 10.0 }
-};
-
-var data = await client.Query(
-    "SELECT * FROM products WHERE id = :product_id AND price >= :min_price", 
-    parameters);
+var data = await client.SqlAsync("SELECT * FROM my_table LIMIT 10;");
 ```
 
 ##### Parameterized Queries with Positional Placeholders
 
-For more control over parameter types, use `QueryWithParams` with positional placeholders (`$1`, `$2`, etc.). This uses the ADBC protocol and supports explicit type specification:
+For queries with user input, use `SqlWithParamsAsync` with positional placeholders (`$1`, `$2`, etc.) instead of interpolating values into the SQL string. This uses the ADBC protocol and supports explicit type specification:
 
-> **Note**: The `QueryWithParams` method requires the ADBC FlightSQL driver to support prepared statements.
+> **Note**: The `SqlWithParamsAsync` method requires the ADBC FlightSQL driver to support prepared statements.
 > The pure C# driver (`Apache.Arrow.Adbc.Drivers.FlightSql`) currently does not implement `Prepare()`.
 > For full parameterized query support, the Go-based interop driver (`Apache.Arrow.Adbc.Drivers.Interop.FlightSql`)
 > is required. See the [Apache ADBC documentation](https://arrow.apache.org/adbc/) for more details.
@@ -73,7 +55,7 @@ using Spice.Params;
 using var client = new SpiceClientBuilder().Build();
 
 // Basic usage with type inference
-var data = await client.QueryWithParams(
+var data = await client.SqlWithParamsAsync(
     "SELECT * FROM products WHERE id = $1 AND price >= $2",
     42,           // Inferred as Int32
     10.50         // Inferred as Double
@@ -97,7 +79,7 @@ using Spice.Params;
 using var client = new SpiceClientBuilder().Build();
 
 // Explicitly typed parameters
-var data = await client.QueryWithParams(
+var data = await client.SqlWithParamsAsync(
     "SELECT * FROM orders WHERE customer_id = $1 AND order_date >= $2 AND total > $3",
     Param.Int64(12345),                           // Explicit Int64
     Param.Date32(new DateTime(2024, 1, 1)),       // Date without time
@@ -120,7 +102,7 @@ var data = await client.QueryWithParams(
 You can mix inferred and explicit types in the same query:
 
 ```csharp
-var data = await client.QueryWithParams(
+var data = await client.SqlWithParamsAsync(
     "SELECT * FROM users WHERE name = $1 AND age > $2 AND verified = $3",
     "John",                    // Inferred as String
     Param.Int16(18),           // Explicit Int16
@@ -256,7 +238,7 @@ using var client = new SpiceClientBuilder()
     .Build();
 ```
 
-#### Query
+#### Sql
 
 ```csharp
 using Spice;
@@ -265,28 +247,10 @@ using var client = new SpiceClientBuilder()
     .WithSpiceCloud("API_KEY")
     .Build();
 
-var data = await client.Query("SELECT * FROM eth.recent_blocks LIMIT 10;");
+var data = await client.SqlAsync("SELECT * FROM eth.recent_blocks LIMIT 10;");
 ```
 
-#### Parameterized Queries
-
-```csharp
-using Spice;
-
-using var client = new SpiceClientBuilder()
-    .WithSpiceCloud("API_KEY")
-    .Build();
-
-var parameters = new Dictionary<string, object>
-{
-    { "nation_name", "CHINA" },
-    { "min_key", 0 }
-};
-
-var data = await client.Query(
-    "SELECT * FROM tpch.nation WHERE n_name = :nation_name AND n_nationkey >= :min_key", 
-    parameters);
-```
+Use `SqlWithParamsAsync` with positional placeholders (`$1`, `$2`, etc.) for queries with user input — see [Parameterized Queries with Positional Placeholders](#parameterized-queries-with-positional-placeholders) above.
 
 #### Refresh Dataset
 
@@ -351,22 +315,22 @@ empty; they default to empty dictionaries, so they can be read without a null ch
 
 #### Async Queries
 
-`SubmitQueryAsync` submits a query for asynchronous execution over Flight and returns an
+`QueryAsync` submits a query for asynchronous execution over Flight and returns an
 `AsyncQuery` handle for polling status and fetching results, instead of streaming results
-directly like `Query`. This requires the runtime to be running in distributed/scheduler mode.
+directly like `SqlAsync`. This requires the runtime to be running in distributed/scheduler mode.
 
 ```csharp
 using Spice;
 
 using var client = new SpiceClientBuilder().Build();
 
-var query = await client.SubmitQueryAsync("SELECT * FROM taxi_trips");
+var query = await client.QueryAsync("SELECT * FROM taxi_trips");
 await query.WaitAsync();
 
 using var results = await query.GetResultsAsync();
 ```
 
-`SubmitQueryWithParamsAsync` submits a parameterized query the same way, binding `$1`, `$2`,
+`QueryWithParamsAsync` submits a parameterized query the same way, binding `$1`, `$2`,
 etc. positionally. An `AsyncQuery` also exposes `GetStatusAsync` for a single status poll and
 `CancelAsync` to request cancellation.
 
@@ -378,13 +342,13 @@ The `SpiceClient` implements `IDisposable` and should be properly disposed to re
 // Using statement (automatically disposes when scope exits)
 using (var client = new SpiceClientBuilder().WithSpiceCloud("API_KEY").Build())
 {
-    var data = await client.Query("SELECT * FROM tpch.customer LIMIT 10;");
+    var data = await client.SqlAsync("SELECT * FROM tpch.customer LIMIT 10;");
     // Process data...
 } // Client is disposed here
 
 // Or using declaration (C# 8.0+)
 using var client = new SpiceClientBuilder().WithSpiceCloud("API_KEY").Build();
-var data = await client.Query("SELECT * FROM tpch.customer LIMIT 10;");
+var data = await client.SqlAsync("SELECT * FROM tpch.customer LIMIT 10;");
 // Client is disposed at end of scope
 ```
 

--- a/README.md
+++ b/README.md
@@ -349,6 +349,27 @@ matched column values in `Matches`, the row's `PrimaryKey`, the columns requeste
 `AdditionalColumns` in `Data`, and any `Metadata`. The runtime omits the last three when
 empty; they default to empty dictionaries, so they can be read without a null check.
 
+#### Async Queries
+
+`SubmitQueryAsync` submits a query for asynchronous execution over Flight and returns an
+`AsyncQuery` handle for polling status and fetching results, instead of streaming results
+directly like `Query`. This requires the runtime to be running in distributed/scheduler mode.
+
+```csharp
+using Spice;
+
+using var client = new SpiceClientBuilder().Build();
+
+var query = await client.SubmitQueryAsync("SELECT * FROM taxi_trips");
+await query.WaitAsync();
+
+using var results = await query.GetResultsAsync();
+```
+
+`SubmitQueryWithParamsAsync` submits a parameterized query the same way, binding `$1`, `$2`,
+etc. positionally. An `AsyncQuery` also exposes `GetStatusAsync` for a single status poll and
+`CancelAsync` to request cancellation.
+
 ### Memory Management
 
 The `SpiceClient` implements `IDisposable` and should be properly disposed to release network resources (gRPC channels, HTTP clients). Use the `using` statement or `using` declaration for automatic disposal:

--- a/Spice/src/Adbc/SpiceAdbcClient.cs
+++ b/Spice/src/Adbc/SpiceAdbcClient.cs
@@ -173,7 +173,7 @@ internal sealed class SpiceAdbcClient : IDisposable
     /// <param name="sql">SQL query with positional placeholders ($1, $2, etc.)</param>
     /// <param name="parameters">The parameter values (can be plain values or Param instances)</param>
     /// <returns>An ArrowArrayStream with the query results</returns>
-    public Task<IArrowArrayStream?> QueryWithParamsAsync(string sql, params object?[] parameters)
+    public Task<IArrowArrayStream?> SqlWithParamsAsync(string sql, params object?[] parameters)
     {
         if (string.IsNullOrEmpty(sql))
         {

--- a/Spice/src/Flight/SpiceFlightClient.cs
+++ b/Spice/src/Flight/SpiceFlightClient.cs
@@ -22,6 +22,7 @@ SOFTWARE.
 
 using System.Net.Http.Headers;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
 using Apache.Arrow.Flight;
 using Apache.Arrow.Flight.Client;
 using Grpc.Core;
@@ -30,6 +31,7 @@ using Polly.Retry;
 using Spice.Auth;
 using Spice.Common;
 using Spice.Errors;
+using Spice.Query;
 
 namespace Spice.Flight;
 
@@ -278,6 +280,56 @@ internal class SpiceFlightClient : IDisposable
             var stream = _flightClient.GetStream(endpoints[0].Ticket);
             return stream.ResponseStream;
         });
+    }
+
+    /// <summary>
+    /// Submits sql for asynchronous execution via Flight DoAction and returns a handle for
+    /// polling status and retrieving results. Only available when the runtime is running in
+    /// distributed/scheduler mode.
+    /// </summary>
+    /// <param name="sql">The SQL to run</param>
+    /// <param name="parameters">Positionally-bound parameter values, or null for none</param>
+    /// <param name="cancellationToken">Token to cancel the submission</param>
+    internal async Task<AsyncQuery> SubmitQueryAsync(string sql, object? parameters, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(sql))
+        {
+            throw new ArgumentException("No SQL provided", nameof(sql));
+        }
+
+        var request = new SubmitAsyncQueryRequest { Sql = sql, Parameters = parameters };
+        var body = await DoActionAsync(AsyncQueryActions.Submit, request, cancellationToken).ConfigureAwait(false);
+
+        var response = JsonSerializer.Deserialize<SubmitAsyncQueryResponse>(body)
+            ?? throw new InvalidOperationException("Failed to parse the submit-async-query response.");
+
+        return new AsyncQuery(this, response.QueryId, response.Status);
+    }
+
+    /// <summary>
+    /// Performs a Flight DoAction call with a JSON-encoded request body and returns the
+    /// concatenated bodies of every result the runtime streams back.
+    /// </summary>
+    /// <remarks>
+    /// Authentication is already applied at channel-construction time (see
+    /// <see cref="AuthenticateAsync"/>), so unlike <see cref="Query"/>'s retry policy this does
+    /// not need a separate auth step per call.
+    /// </remarks>
+    internal async Task<byte[]> DoActionAsync(string actionType, object request, CancellationToken cancellationToken = default)
+    {
+        var body = JsonSerializer.SerializeToUtf8Bytes(request);
+        var action = new FlightAction(actionType, body);
+
+        using var call = _flightClient.DoAction(action, new Metadata(), null, cancellationToken);
+
+        using var buffer = new MemoryStream();
+        while (await call.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false))
+        {
+            var chunk = call.ResponseStream.Current.Body.ToByteArray();
+            buffer.Write(chunk, 0, chunk.Length);
+        }
+
+        return buffer.ToArray();
     }
 
     private bool _disposed;

--- a/Spice/src/Flight/SpiceFlightClient.cs
+++ b/Spice/src/Flight/SpiceFlightClient.cs
@@ -259,7 +259,7 @@ internal class SpiceFlightClient : IDisposable
         };
     }
 
-    internal async Task<FlightClientRecordBatchStreamReader> Query(string sql)
+    internal async Task<FlightClientRecordBatchStreamReader> SqlAsync(string sql)
     {
         if (string.IsNullOrEmpty(sql))
         {
@@ -290,7 +290,7 @@ internal class SpiceFlightClient : IDisposable
     /// <param name="sql">The SQL to run</param>
     /// <param name="parameters">Positionally-bound parameter values, or null for none</param>
     /// <param name="cancellationToken">Token to cancel the submission</param>
-    internal async Task<AsyncQuery> SubmitQueryAsync(string sql, object? parameters, CancellationToken cancellationToken)
+    internal async Task<AsyncQuery> QueryAsync(string sql, object? parameters, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(sql))
         {

--- a/Spice/src/Query/AsyncQuery.cs
+++ b/Spice/src/Query/AsyncQuery.cs
@@ -30,7 +30,7 @@ namespace Spice.Query;
 
 /// <summary>
 /// A handle to a query submitted for asynchronous execution via
-/// <see cref="SpiceClient.SubmitQueryAsync"/> or <see cref="SpiceClient.SubmitQueryWithParamsAsync"/>.
+/// <see cref="SpiceClient.QueryAsync"/> or <see cref="SpiceClient.QueryWithParamsAsync"/>.
 /// </summary>
 /// <remarks>
 /// Not safe for concurrent use from multiple threads.

--- a/Spice/src/Query/AsyncQuery.cs
+++ b/Spice/src/Query/AsyncQuery.cs
@@ -1,0 +1,195 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using Grpc.Core;
+using Spice.Flight;
+
+namespace Spice.Query;
+
+/// <summary>
+/// A handle to a query submitted for asynchronous execution via
+/// <see cref="SpiceClient.SubmitQueryAsync"/> or <see cref="SpiceClient.SubmitQueryWithParamsAsync"/>.
+/// </summary>
+/// <remarks>
+/// Not safe for concurrent use from multiple threads.
+/// </remarks>
+public sealed class AsyncQuery
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(500);
+
+    private readonly SpiceFlightClient _client;
+
+    internal AsyncQuery(SpiceFlightClient client, string queryId, QueryStatus status)
+    {
+        _client = client;
+        Id = queryId;
+        Status = status;
+    }
+
+    /// <summary>
+    /// The server-assigned query identifier.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// The status as of the last poll. Set on construction and refreshed by
+    /// <see cref="GetStatusAsync"/>, <see cref="WaitAsync"/>, <see cref="GetResultsAsync"/>
+    /// and <see cref="CancelAsync"/>.
+    /// </summary>
+    public QueryStatus Status { get; private set; }
+
+    /// <summary>
+    /// Polls the runtime once and returns the query's current status.
+    /// </summary>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    /// <returns>The current status</returns>
+    public async Task<QueryStatus> GetStatusAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await PollStatusAsync(cancellationToken).ConfigureAwait(false);
+        return response.Status;
+    }
+
+    /// <summary>
+    /// Polls the runtime until the query reaches a terminal status (Succeeded, Failed,
+    /// Cancelled, or Closed) or <paramref name="cancellationToken"/> is cancelled.
+    /// </summary>
+    /// <param name="cancellationToken">Token to cancel waiting</param>
+    /// <returns>The terminal status</returns>
+    public async Task<QueryStatus> WaitAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await WaitForTerminalAsync(cancellationToken).ConfigureAwait(false);
+        return response.Status;
+    }
+
+    /// <summary>
+    /// Waits for the query to complete and returns its results as an Apache Arrow stream.
+    /// The caller must dispose the returned stream.
+    /// </summary>
+    /// <remarks>
+    /// If the query does not succeed, this throws an <see cref="InvalidOperationException"/>
+    /// describing the terminal status, including the runtime's error message when available.
+    /// </remarks>
+    /// <param name="cancellationToken">Token to cancel waiting and fetching</param>
+    /// <returns>The query's results</returns>
+    /// <exception cref="System.InvalidOperationException">Thrown when the query did not succeed</exception>
+    public async Task<IArrowArrayStream> GetResultsAsync(CancellationToken cancellationToken = default)
+    {
+        var statusResponse = await WaitForTerminalAsync(cancellationToken).ConfigureAwait(false);
+
+        if (statusResponse.Status != QueryStatus.Succeeded)
+        {
+            var reason = statusResponse.Error?.ToString();
+            var detail = string.IsNullOrEmpty(reason) ? $"status: {statusResponse.Status}" : reason;
+            throw new InvalidOperationException($"Async query {Id} did not succeed ({detail}).");
+        }
+
+        var chunkCount = statusResponse.Result?.TotalChunkCount ?? 0;
+        // Always fetch at least once so a genuinely empty result still yields a schema.
+        var fetchCount = Math.Max(chunkCount, 1);
+
+        Schema? schema = null;
+        var batches = new List<RecordBatch>();
+
+        for (var i = 0; i < fetchCount; i++)
+        {
+            byte[] chunkBytes;
+            try
+            {
+                chunkBytes = await _client.DoActionAsync(
+                    AsyncQueryActions.GetResult,
+                    new GetAsyncQueryResultRequest { QueryId = Id, ChunkIndex = i },
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (RpcException) when (i == 0 && chunkCount == 0)
+            {
+                // A missing chunk 0 on a genuinely empty result is not an error.
+                break;
+            }
+
+            using var chunkStream = new MemoryStream(chunkBytes);
+            using var reader = new ArrowStreamReader(chunkStream);
+
+            RecordBatch? batch;
+            while ((batch = await reader.ReadNextRecordBatchAsync(cancellationToken).ConfigureAwait(false)) != null)
+            {
+                schema ??= reader.Schema;
+                batches.Add(batch);
+            }
+        }
+
+        schema ??= new Schema.Builder().Build();
+        return new InMemoryRecordBatchStream(schema, batches);
+    }
+
+    /// <summary>
+    /// Requests cancellation of the query.
+    /// </summary>
+    /// <remarks>
+    /// Best-effort: a query that has already reached a terminal status is not cancelled,
+    /// which is not reported as an error. Inspect <see cref="Status"/> after this call to
+    /// observe the outcome.
+    /// </remarks>
+    /// <param name="cancellationToken">Token to cancel the request</param>
+    public async Task CancelAsync(CancellationToken cancellationToken = default)
+    {
+        var body = await _client.DoActionAsync(
+            AsyncQueryActions.Cancel,
+            new CancelAsyncQueryRequest { QueryId = Id },
+            cancellationToken).ConfigureAwait(false);
+
+        var response = JsonSerializer.Deserialize<CancelAsyncQueryResponse>(body)
+            ?? throw new InvalidOperationException("Failed to parse the cancel-async-query response.");
+
+        Status = response.Status;
+    }
+
+    private async Task<GetAsyncQueryStatusResponse> PollStatusAsync(CancellationToken cancellationToken)
+    {
+        var body = await _client.DoActionAsync(
+            AsyncQueryActions.GetStatus,
+            new GetAsyncQueryStatusRequest { QueryId = Id },
+            cancellationToken).ConfigureAwait(false);
+
+        var response = JsonSerializer.Deserialize<GetAsyncQueryStatusResponse>(body)
+            ?? throw new InvalidOperationException("Failed to parse the async query status response.");
+
+        Status = response.Status;
+        return response;
+    }
+
+    private async Task<GetAsyncQueryStatusResponse> WaitForTerminalAsync(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var response = await PollStatusAsync(cancellationToken).ConfigureAwait(false);
+            if (response.Status.IsTerminal())
+            {
+                return response;
+            }
+
+            await Task.Delay(PollInterval, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/Spice/src/Query/AsyncQueryWireTypes.cs
+++ b/Spice/src/Query/AsyncQueryWireTypes.cs
@@ -1,0 +1,134 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Spice.Query;
+
+/// <summary>
+/// The Flight DoAction action types the runtime serves for async queries. Only available
+/// when the runtime is running in distributed/scheduler mode.
+/// </summary>
+internal static class AsyncQueryActions
+{
+    internal const string Submit = "SubmitAsyncQuery";
+    internal const string GetStatus = "GetAsyncQueryStatus";
+    internal const string GetResult = "GetAsyncQueryResult";
+    internal const string Cancel = "CancelAsyncQuery";
+}
+
+internal sealed class SubmitAsyncQueryRequest
+{
+    [JsonPropertyName("sql")]
+    public string Sql { get; set; } = string.Empty;
+
+    // Positionally-bound parameter values ($1, $2, ...), sent as-is so each must already be a
+    // JSON-encodable value.
+    [JsonPropertyName("parameters")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public object? Parameters { get; set; }
+}
+
+internal sealed class SubmitAsyncQueryResponse
+{
+    [JsonPropertyName("query_id")]
+    public string QueryId { get; set; } = string.Empty;
+
+    [JsonPropertyName("status")]
+    public QueryStatus Status { get; set; }
+}
+
+internal sealed class GetAsyncQueryStatusRequest
+{
+    [JsonPropertyName("query_id")]
+    public string QueryId { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// The runtime's description of why an async query did not succeed.
+/// </summary>
+internal sealed class AsyncQueryError
+{
+    [JsonPropertyName("error_code")]
+    public JsonElement ErrorCode { get; set; }
+
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = string.Empty;
+
+    public override string ToString()
+    {
+        var code = ErrorCode.ValueKind == JsonValueKind.String ? ErrorCode.GetString() : null;
+        return string.IsNullOrEmpty(code) ? Message : $"{code}: {Message}";
+    }
+}
+
+internal sealed class AsyncQueryResultMetadata
+{
+    [JsonPropertyName("total_row_count")]
+    public long TotalRowCount { get; set; }
+
+    [JsonPropertyName("total_chunk_count")]
+    public int TotalChunkCount { get; set; }
+}
+
+internal sealed class GetAsyncQueryStatusResponse
+{
+    [JsonPropertyName("query_id")]
+    public string QueryId { get; set; } = string.Empty;
+
+    [JsonPropertyName("status")]
+    public QueryStatus Status { get; set; }
+
+    [JsonPropertyName("error")]
+    public AsyncQueryError? Error { get; set; }
+
+    [JsonPropertyName("result")]
+    public AsyncQueryResultMetadata? Result { get; set; }
+}
+
+internal sealed class GetAsyncQueryResultRequest
+{
+    [JsonPropertyName("query_id")]
+    public string QueryId { get; set; } = string.Empty;
+
+    [JsonPropertyName("chunk_index")]
+    public int ChunkIndex { get; set; }
+}
+
+internal sealed class CancelAsyncQueryRequest
+{
+    [JsonPropertyName("query_id")]
+    public string QueryId { get; set; } = string.Empty;
+}
+
+internal sealed class CancelAsyncQueryResponse
+{
+    [JsonPropertyName("query_id")]
+    public string QueryId { get; set; } = string.Empty;
+
+    [JsonPropertyName("cancelled")]
+    public bool Cancelled { get; set; }
+
+    [JsonPropertyName("status")]
+    public QueryStatus Status { get; set; }
+}

--- a/Spice/src/Query/InMemoryRecordBatchStream.cs
+++ b/Spice/src/Query/InMemoryRecordBatchStream.cs
@@ -1,0 +1,58 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+
+namespace Spice.Query;
+
+/// <summary>
+/// An <see cref="IArrowArrayStream"/> over record batches that have already been fully
+/// decoded into memory, used to hand back the chunks fetched for an async query's results.
+/// </summary>
+internal sealed class InMemoryRecordBatchStream : IArrowArrayStream
+{
+    private readonly IReadOnlyList<RecordBatch> _batches;
+    private int _index;
+
+    internal InMemoryRecordBatchStream(Schema schema, IReadOnlyList<RecordBatch> batches)
+    {
+        Schema = schema;
+        _batches = batches;
+    }
+
+    public Schema Schema { get; }
+
+    public ValueTask<RecordBatch> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
+    {
+        var batch = _index < _batches.Count ? _batches[_index++] : null;
+        return new ValueTask<RecordBatch>(batch!);
+    }
+
+    public void Dispose()
+    {
+        foreach (var batch in _batches)
+        {
+            batch.Dispose();
+        }
+    }
+}

--- a/Spice/src/Query/QueryStatus.cs
+++ b/Spice/src/Query/QueryStatus.cs
@@ -1,0 +1,101 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Spice.Query;
+
+/// <summary>
+/// The lifecycle status of an async query, as reported by the Spice runtime.
+/// </summary>
+[JsonConverter(typeof(QueryStatusJsonConverter))]
+public enum QueryStatus
+{
+    /// <summary>The query has been submitted but has not started running.</summary>
+    Pending,
+
+    /// <summary>The query is running.</summary>
+    Running,
+
+    /// <summary>The query finished successfully and its results are available.</summary>
+    Succeeded,
+
+    /// <summary>The query failed. See <see cref="AsyncQuery.GetResultsAsync"/> for the runtime's error message.</summary>
+    Failed,
+
+    /// <summary>The query was cancelled before it finished.</summary>
+    Cancelled,
+
+    /// <summary>The query's results have been released by the runtime.</summary>
+    Closed,
+}
+
+/// <summary>
+/// Extension methods for <see cref="QueryStatus"/>.
+/// </summary>
+public static class QueryStatusExtensions
+{
+    /// <summary>
+    /// Reports whether the status is terminal, i.e. the query will not transition further.
+    /// </summary>
+    /// <param name="status">The status to check</param>
+    /// <returns>True when the query has finished, failed, or been cancelled or closed</returns>
+    public static bool IsTerminal(this QueryStatus status) =>
+        status is QueryStatus.Succeeded or QueryStatus.Failed or QueryStatus.Cancelled or QueryStatus.Closed;
+}
+
+/// <summary>
+/// Converts <see cref="QueryStatus"/> to and from the runtime's uppercase wire representation
+/// (for example <c>"SUCCEEDED"</c>).
+/// </summary>
+internal sealed class QueryStatusJsonConverter : JsonConverter<QueryStatus>
+{
+    public override QueryStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        return value switch
+        {
+            "PENDING" => QueryStatus.Pending,
+            "RUNNING" => QueryStatus.Running,
+            "SUCCEEDED" => QueryStatus.Succeeded,
+            "FAILED" => QueryStatus.Failed,
+            "CANCELLED" => QueryStatus.Cancelled,
+            "CLOSED" => QueryStatus.Closed,
+            _ => throw new JsonException($"Unrecognized query status \"{value}\"."),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, QueryStatus value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value switch
+        {
+            QueryStatus.Pending => "PENDING",
+            QueryStatus.Running => "RUNNING",
+            QueryStatus.Succeeded => "SUCCEEDED",
+            QueryStatus.Failed => "FAILED",
+            QueryStatus.Cancelled => "CANCELLED",
+            QueryStatus.Closed => "CLOSED",
+            _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Unsupported query status."),
+        });
+    }
+}

--- a/Spice/src/SpiceClient.cs
+++ b/Spice/src/SpiceClient.cs
@@ -27,6 +27,7 @@ using Spice.Config;
 using Spice.Datasets;
 using Spice.Flight;
 using Spice.Http;
+using Spice.Query;
 using Spice.Search;
 
 namespace Spice;
@@ -296,6 +297,65 @@ public class SpiceClient : IDisposable
         if (HttpClient == null) throw new InvalidOperationException("HttpClient not initialized");
 
         return HttpClient.SearchAsync(request, cancellationToken);
+    }
+
+    /// <summary>
+    /// Submits sql to the Spice runtime for asynchronous execution and returns a handle for
+    /// polling status and retrieving results.
+    /// </summary>
+    /// <remarks>
+    /// Async queries require the runtime to be running in distributed/scheduler mode; against
+    /// a single-node runtime the runtime returns an error explaining that async queries are
+    /// only available in cluster mode. Use <see cref="Query"/> for synchronous, streaming queries.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var query = await client.SubmitQueryAsync("SELECT * FROM taxi_trips");
+    /// await query.WaitAsync();
+    /// using var results = await query.GetResultsAsync();
+    /// </code>
+    /// </example>
+    /// <param name="sql">SQL to run asynchronously</param>
+    /// <param name="cancellationToken">Token to cancel the submission</param>
+    /// <returns>A handle for polling status and retrieving results</returns>
+    /// <exception cref="System.ArgumentException">Thrown when provided sql is null or empty</exception>
+    /// <exception cref="System.InvalidOperationException">Thrown when the client is not initialized</exception>
+    public Task<AsyncQuery> SubmitQueryAsync(string sql, CancellationToken cancellationToken = default)
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(_disposed, this);
+#else
+        if (_disposed) throw new ObjectDisposedException(GetType().FullName);
+#endif
+        if (FlightClient == null) throw new InvalidOperationException("FlightClient not initialized");
+
+        return FlightClient.SubmitQueryAsync(sql, null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Submits a parameterized query for asynchronous execution. Parameters are bound
+    /// positionally ($1, $2, ...) and sent as a JSON array, so each must be a JSON-encodable value.
+    /// </summary>
+    /// <remarks>
+    /// Async queries require the runtime to be running in distributed/scheduler mode. Use
+    /// <see cref="QueryWithParams"/> for synchronous, streaming parameterized queries.
+    /// </remarks>
+    /// <param name="sql">SQL query with positional parameter placeholders ($1, $2, etc.)</param>
+    /// <param name="parameters">The parameter values</param>
+    /// <returns>A handle for polling status and retrieving results</returns>
+    /// <exception cref="System.ArgumentException">Thrown when provided sql is null or empty</exception>
+    /// <exception cref="System.InvalidOperationException">Thrown when the client is not initialized</exception>
+    public Task<AsyncQuery> SubmitQueryWithParamsAsync(string sql, params object?[] parameters)
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(_disposed, this);
+#else
+        if (_disposed) throw new ObjectDisposedException(GetType().FullName);
+#endif
+        if (FlightClient == null) throw new InvalidOperationException("FlightClient not initialized");
+
+        object? boundParameters = parameters.Length > 0 ? parameters : null;
+        return FlightClient.SubmitQueryAsync(sql, boundParameters, CancellationToken.None);
     }
 
     private bool _disposed;

--- a/Spice/src/SpiceClient.cs
+++ b/Spice/src/SpiceClient.cs
@@ -110,14 +110,19 @@ public class SpiceClient : IDisposable
     }
 
     /// <summary>
-    /// Runs the query against the Flight endpoint. 
+    /// Runs sql against the Flight endpoint and streams the results back synchronously.
     /// </summary>
+    /// <remarks>
+    /// Use <see cref="QueryAsync"/> instead to submit sql for asynchronous execution on the
+    /// runtime and poll for completion, which requires the runtime to be running in
+    /// distributed/scheduler mode.
+    /// </remarks>
     /// <returns>A task representing asynchronus operation, with a result of type <see cref="FlightClientRecordBatchStreamReader"/></returns>
     /// <param name="sql">SQL to be executed against Spice</param>
     /// <exception cref="System.ArgumentException">Thrown when provided sql is null or empty</exception>
     /// <exception cref="Spice.Errors.SpiceException">Spice exception</exception>
     /// <exception cref="Grpc.Core.RpcException">gRPC exception</exception>
-    public Task<FlightClientRecordBatchStreamReader> Query(string sql)
+    public Task<FlightClientRecordBatchStreamReader> SqlAsync(string sql)
     {
 #if NET8_0_OR_GREATER
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -126,14 +131,14 @@ public class SpiceClient : IDisposable
 #endif
         if (FlightClient == null) throw new InvalidOperationException("FlightClient not initialized");
 
-        return FlightClient.Query(sql);
+        return FlightClient.SqlAsync(sql);
     }
 
     /// <summary>
-    /// Executes a parameterized SQL query using ADBC (Arrow Database Connectivity).
+    /// Executes a parameterized SQL query synchronously using ADBC (Arrow Database Connectivity).
     /// This is the recommended method for queries with user input to prevent SQL injection.
     /// Parameters should use positional placeholders ($1, $2, etc.) in the SQL query.
-    /// 
+    ///
     /// <para>
     /// Parameters can be:
     /// <list type="bullet">
@@ -141,27 +146,31 @@ public class SpiceClient : IDisposable
     /// <item><description>Param instances with explicit type annotation using Param factory methods</description></item>
     /// </list>
     /// </para>
-    /// 
+    ///
     /// <example>
     /// <code>
     /// // With automatic type inference
-    /// var result = await client.QueryWithParams(
+    /// var result = await client.SqlWithParamsAsync(
     ///     "SELECT * FROM table WHERE id = $1 AND name = $2",
     ///     123, "test");
-    /// 
+    ///
     /// // With explicit types
-    /// var result = await client.QueryWithParams(
+    /// var result = await client.SqlWithParamsAsync(
     ///     "SELECT * FROM table WHERE id = $1 AND amount = $2",
     ///     Param.Int32(123), Param.Double(99.99));
     /// </code>
     /// </example>
     /// </summary>
+    /// <remarks>
+    /// Use <see cref="QueryWithParamsAsync"/> instead to submit the parameterized query for
+    /// asynchronous execution on the runtime, which requires distributed/scheduler mode.
+    /// </remarks>
     /// <param name="sql">SQL query with positional parameter placeholders ($1, $2, etc.)</param>
     /// <param name="parameters">The parameter values (can be plain values or Param instances)</param>
     /// <returns>A task representing the asynchronous operation, with an IArrowArrayStream result</returns>
     /// <exception cref="System.ArgumentException">Thrown when provided sql is null or empty</exception>
     /// <exception cref="System.InvalidOperationException">Thrown when the client is not initialized</exception>
-    public Task<IArrowArrayStream?> QueryWithParams(string sql, params object?[] parameters)
+    public Task<IArrowArrayStream?> SqlWithParamsAsync(string sql, params object?[] parameters)
     {
 #if NET8_0_OR_GREATER
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -170,7 +179,7 @@ public class SpiceClient : IDisposable
 #endif
         if (AdbcClient == null) throw new InvalidOperationException("AdbcClient not initialized");
 
-        return AdbcClient.QueryWithParamsAsync(sql, parameters);
+        return AdbcClient.SqlWithParamsAsync(sql, parameters);
     }
 
     /// <summary>
@@ -306,11 +315,11 @@ public class SpiceClient : IDisposable
     /// <remarks>
     /// Async queries require the runtime to be running in distributed/scheduler mode; against
     /// a single-node runtime the runtime returns an error explaining that async queries are
-    /// only available in cluster mode. Use <see cref="Query"/> for synchronous, streaming queries.
+    /// only available in cluster mode. Use <see cref="SqlAsync"/> for synchronous, streaming queries.
     /// </remarks>
     /// <example>
     /// <code>
-    /// var query = await client.SubmitQueryAsync("SELECT * FROM taxi_trips");
+    /// var query = await client.QueryAsync("SELECT * FROM taxi_trips");
     /// await query.WaitAsync();
     /// using var results = await query.GetResultsAsync();
     /// </code>
@@ -320,7 +329,7 @@ public class SpiceClient : IDisposable
     /// <returns>A handle for polling status and retrieving results</returns>
     /// <exception cref="System.ArgumentException">Thrown when provided sql is null or empty</exception>
     /// <exception cref="System.InvalidOperationException">Thrown when the client is not initialized</exception>
-    public Task<AsyncQuery> SubmitQueryAsync(string sql, CancellationToken cancellationToken = default)
+    public Task<AsyncQuery> QueryAsync(string sql, CancellationToken cancellationToken = default)
     {
 #if NET8_0_OR_GREATER
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -329,7 +338,7 @@ public class SpiceClient : IDisposable
 #endif
         if (FlightClient == null) throw new InvalidOperationException("FlightClient not initialized");
 
-        return FlightClient.SubmitQueryAsync(sql, null, cancellationToken);
+        return FlightClient.QueryAsync(sql, null, cancellationToken);
     }
 
     /// <summary>
@@ -338,14 +347,14 @@ public class SpiceClient : IDisposable
     /// </summary>
     /// <remarks>
     /// Async queries require the runtime to be running in distributed/scheduler mode. Use
-    /// <see cref="QueryWithParams"/> for synchronous, streaming parameterized queries.
+    /// <see cref="SqlWithParamsAsync"/> for synchronous, streaming parameterized queries.
     /// </remarks>
     /// <param name="sql">SQL query with positional parameter placeholders ($1, $2, etc.)</param>
     /// <param name="parameters">The parameter values</param>
     /// <returns>A handle for polling status and retrieving results</returns>
     /// <exception cref="System.ArgumentException">Thrown when provided sql is null or empty</exception>
     /// <exception cref="System.InvalidOperationException">Thrown when the client is not initialized</exception>
-    public Task<AsyncQuery> SubmitQueryWithParamsAsync(string sql, params object?[] parameters)
+    public Task<AsyncQuery> QueryWithParamsAsync(string sql, params object?[] parameters)
     {
 #if NET8_0_OR_GREATER
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -355,7 +364,7 @@ public class SpiceClient : IDisposable
         if (FlightClient == null) throw new InvalidOperationException("FlightClient not initialized");
 
         object? boundParameters = parameters.Length > 0 ? parameters : null;
-        return FlightClient.SubmitQueryAsync(sql, boundParameters, CancellationToken.None);
+        return FlightClient.QueryAsync(sql, boundParameters, CancellationToken.None);
     }
 
     private bool _disposed;

--- a/SpiceTest/AsyncQueryTest.cs
+++ b/SpiceTest/AsyncQueryTest.cs
@@ -1,0 +1,337 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using Apache.Arrow;
+using Apache.Arrow.Flight;
+using Apache.Arrow.Flight.Server;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+using Grpc.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Spice;
+using Spice.Query;
+
+namespace SpiceTest;
+
+/// <summary>
+/// Covers async query submission over Flight DoAction against an in-process Flight server,
+/// so the behaviour is verified without a live, cluster-mode Spice runtime.
+/// </summary>
+public class AsyncQueryTest
+{
+    [OneTimeSetUp]
+    public void OneTimeSetup()
+    {
+        // Required once per process for the Grpc.Net.Client HttpClient to speak plaintext HTTP/2
+        // to the loopback test server (no TLS in tests).
+        AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+    }
+
+    // ==================== Submit + status ====================
+
+    [Test]
+    public async Task Test_SubmitQueryAsync_ReturnsHandle_WithInitialStatus()
+    {
+        await using var server = await AsyncQueryTestServer.StartAsync();
+        server.On(AsyncQueryActions.Submit, _ => """{"query_id":"q-1","status":"PENDING"}""");
+        server.On(AsyncQueryActions.GetStatus, _ => """{"query_id":"q-1","status":"RUNNING"}""");
+
+        using var client = server.BuildClient();
+
+        var query = await client.SubmitQueryAsync("SELECT 1");
+
+        Assert.That(query.Id, Is.EqualTo("q-1"));
+        Assert.That(query.Status, Is.EqualTo(QueryStatus.Pending));
+
+        var status = await query.GetStatusAsync();
+
+        Assert.That(status, Is.EqualTo(QueryStatus.Running));
+        Assert.That(query.Status, Is.EqualTo(QueryStatus.Running));
+    }
+
+    [Test]
+    public async Task Test_WaitAsync_PollsUntilTerminal()
+    {
+        await using var server = await AsyncQueryTestServer.StartAsync();
+        server.On(AsyncQueryActions.Submit, _ => """{"query_id":"q-2","status":"PENDING"}""");
+
+        var polls = 0;
+        server.On(AsyncQueryActions.GetStatus, _ =>
+        {
+            polls++;
+            return polls < 3
+                ? """{"query_id":"q-2","status":"RUNNING"}"""
+                : """{"query_id":"q-2","status":"SUCCEEDED","result":{"total_row_count":0,"total_chunk_count":0}}""";
+        });
+
+        using var client = server.BuildClient();
+        var query = await client.SubmitQueryAsync("SELECT 1");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var status = await query.WaitAsync(cts.Token);
+
+        Assert.That(status, Is.EqualTo(QueryStatus.Succeeded));
+        Assert.That(polls, Is.GreaterThanOrEqualTo(3));
+    }
+
+    // ==================== Results ====================
+
+    [Test]
+    public async Task Test_GetResultsAsync_EmptyResult_ReturnsNoRecords()
+    {
+        await using var server = await AsyncQueryTestServer.StartAsync();
+        server.On(AsyncQueryActions.Submit, _ => """{"query_id":"q-3","status":"PENDING"}""");
+        server.On(AsyncQueryActions.GetStatus, _ =>
+            """{"query_id":"q-3","status":"SUCCEEDED","result":{"total_row_count":0,"total_chunk_count":0}}""");
+        server.On(AsyncQueryActions.GetResult, _ => throw new RpcException(new Status(StatusCode.NotFound, "no chunks for an empty result")));
+
+        using var client = server.BuildClient();
+        var query = await client.SubmitQueryAsync("SELECT 1 WHERE false");
+
+        using var reader = await query.GetResultsAsync();
+        var batch = await reader.ReadNextRecordBatchAsync();
+
+        Assert.That(batch, Is.Null);
+    }
+
+    [Test]
+    public async Task Test_GetResultsAsync_OneChunk_DecodesData()
+    {
+        var chunk = BuildInt64Chunk("n", new long[] { 1, 2, 3 });
+
+        await using var server = await AsyncQueryTestServer.StartAsync();
+        server.On(AsyncQueryActions.Submit, _ => """{"query_id":"q-4","status":"PENDING"}""");
+        server.On(AsyncQueryActions.GetStatus, _ =>
+            """{"query_id":"q-4","status":"SUCCEEDED","result":{"total_row_count":3,"total_chunk_count":1}}""");
+        server.OnBytes(AsyncQueryActions.GetResult, _ => chunk);
+
+        using var client = server.BuildClient();
+        var query = await client.SubmitQueryAsync("SELECT n FROM t");
+
+        using var reader = await query.GetResultsAsync();
+        var batch = await reader.ReadNextRecordBatchAsync();
+
+        Assert.That(batch, Is.Not.Null);
+        Assert.That(batch!.Length, Is.EqualTo(3));
+        var column = (Int64Array)batch.Column(0);
+        Assert.That(new[] { column.GetValue(0), column.GetValue(1), column.GetValue(2) }, Is.EqualTo(new long?[] { 1, 2, 3 }));
+
+        Assert.That(await reader.ReadNextRecordBatchAsync(), Is.Null);
+    }
+
+    [Test]
+    public async Task Test_GetResultsAsync_FailedQuery_SurfacesRuntimeError()
+    {
+        await using var server = await AsyncQueryTestServer.StartAsync();
+        server.On(AsyncQueryActions.Submit, _ => """{"query_id":"q-5","status":"PENDING"}""");
+        server.On(AsyncQueryActions.GetStatus, _ =>
+            """{"query_id":"q-5","status":"FAILED","error":{"error_code":"QueryExecutionError","message":"boom"}}""");
+
+        using var client = server.BuildClient();
+        var query = await client.SubmitQueryAsync("SELECT 1/0");
+
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await query.GetResultsAsync());
+        Assert.That(ex!.Message, Does.Contain("boom"));
+    }
+
+    // ==================== Cancel ====================
+
+    [Test]
+    public async Task Test_CancelAsync_UpdatesStatus_AndCallsActionOnce()
+    {
+        await using var server = await AsyncQueryTestServer.StartAsync();
+        server.On(AsyncQueryActions.Submit, _ => """{"query_id":"q-6","status":"RUNNING"}""");
+        server.On(AsyncQueryActions.Cancel, _ => """{"query_id":"q-6","cancelled":true,"status":"CANCELLED"}""");
+
+        using var client = server.BuildClient();
+        var query = await client.SubmitQueryAsync("SELECT 1");
+
+        await query.CancelAsync();
+
+        Assert.That(query.Status, Is.EqualTo(QueryStatus.Cancelled));
+        Assert.That(server.CallCount(AsyncQueryActions.Cancel), Is.EqualTo(1));
+    }
+
+    // ==================== Parameters ====================
+
+    [Test]
+    public async Task Test_SubmitQueryWithParamsAsync_PlacesSqlAndParametersInRequestBody()
+    {
+        string? submittedBody = null;
+
+        await using var server = await AsyncQueryTestServer.StartAsync();
+        server.On(AsyncQueryActions.Submit, body =>
+        {
+            submittedBody = body;
+            return """{"query_id":"q-7","status":"PENDING"}""";
+        });
+
+        using var client = server.BuildClient();
+        await client.SubmitQueryWithParamsAsync("SELECT * FROM t WHERE id = $1", 42);
+
+        Assert.That(submittedBody, Is.Not.Null);
+        using var document = JsonDocument.Parse(submittedBody!);
+        Assert.Multiple(() =>
+        {
+            Assert.That(document.RootElement.GetProperty("sql").GetString(), Is.EqualTo("SELECT * FROM t WHERE id = $1"));
+            Assert.That(document.RootElement.GetProperty("parameters")[0].GetInt32(), Is.EqualTo(42));
+        });
+    }
+
+    [Test]
+    public async Task Test_SubmitQueryAsync_WithoutParams_OmitsParametersField()
+    {
+        string? submittedBody = null;
+
+        await using var server = await AsyncQueryTestServer.StartAsync();
+        server.On(AsyncQueryActions.Submit, body =>
+        {
+            submittedBody = body;
+            return """{"query_id":"q-8","status":"PENDING"}""";
+        });
+
+        using var client = server.BuildClient();
+        await client.SubmitQueryAsync("SELECT 1");
+
+        using var document = JsonDocument.Parse(submittedBody!);
+        Assert.That(document.RootElement.TryGetProperty("parameters", out _), Is.False);
+    }
+
+    // ==================== Helpers ====================
+
+    private static byte[] BuildInt64Chunk(string columnName, long[] values)
+    {
+        var schema = new Schema.Builder().Field(f => f.Name(columnName).DataType(Int64Type.Default).Nullable(false)).Build();
+
+        var builder = new Int64Array.Builder();
+        builder.AppendRange(values);
+        var column = builder.Build();
+
+        using var batch = new RecordBatch(schema, new IArrowArray[] { column }, values.Length);
+        using var stream = new MemoryStream();
+        using (var writer = new ArrowStreamWriter(stream, schema))
+        {
+            writer.WriteRecordBatch(batch);
+            writer.WriteEnd();
+        }
+
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Minimal in-process Flight server hosting only DoAction, driven by per-action-type
+    /// handlers registered by each test. Lets tests stay declarative instead of each writing
+    /// its own <see cref="FlightServer"/> subclass.
+    /// </summary>
+    private sealed class AsyncQueryTestServer : IAsyncDisposable
+    {
+        private readonly WebApplication _app;
+
+        private AsyncQueryTestServer(WebApplication app)
+        {
+            _app = app;
+        }
+
+        public static async Task<AsyncQueryTestServer> StartAsync()
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.WebHost.ConfigureKestrel(o =>
+                o.Listen(System.Net.IPAddress.Loopback, 0, lo => lo.Protocols = HttpProtocols.Http2));
+            builder.Services.AddGrpc().AddFlightServer<TestFlightServer>();
+
+            // AddFlightServer<T>() activates T itself for each DoAction call (its own DI
+            // container path, not visibly affected by registering T with a different
+            // lifetime), so a per-instance Handlers dictionary set up before the request is
+            // sent would not be visible to the instance that actually serves it. Route
+            // through process-wide static state instead, reset per server instance -- tests
+            // in this fixture run sequentially and each owns its own server/port.
+            TestFlightServer.Reset();
+
+            var app = builder.Build();
+            app.MapFlightEndpoint();
+            await app.StartAsync().ConfigureAwait(false);
+
+            return new AsyncQueryTestServer(app);
+        }
+
+        public string Address => _app.Urls.First();
+
+        // These forward to TestFlightServer's static state (see the comment in StartAsync)
+        // rather than an instance field, so they don't access `this` -- kept as instance
+        // members anyway since conceptually they configure this particular server instance.
+#pragma warning disable CA1822
+        /// <summary>Registers a handler that returns a UTF-8 JSON/text response body.</summary>
+        public void On(string actionType, Func<string, string> handler) =>
+            TestFlightServer.Handlers[actionType] = body => Encoding.UTF8.GetBytes(handler(Encoding.UTF8.GetString(body)));
+
+        /// <summary>Registers a handler that returns a raw response body (for Arrow IPC chunks).</summary>
+        public void OnBytes(string actionType, Func<byte[], byte[]> handler) =>
+            TestFlightServer.Handlers[actionType] = handler;
+
+        public int CallCount(string actionType) => TestFlightServer.CallCounts.GetOrAdd(actionType, 0);
+#pragma warning restore CA1822
+
+        public SpiceClient BuildClient() => new SpiceClientBuilder().WithFlightAddress(Address).Build();
+
+        public async ValueTask DisposeAsync()
+        {
+            await _app.StopAsync().ConfigureAwait(false);
+            await _app.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private sealed class TestFlightServer : FlightServer
+    {
+        // Static: the ASP.NET Core gRPC host activates a new TestFlightServer per DoAction
+        // call, so per-instance state set up by a test would never reach the instance that
+        // serves the request. See the comment in AsyncQueryTestServer.StartAsync.
+        public static ConcurrentDictionary<string, Func<byte[], byte[]>> Handlers { get; private set; } = new();
+        public static ConcurrentDictionary<string, int> CallCounts { get; private set; } = new();
+
+        public static void Reset()
+        {
+            Handlers = new ConcurrentDictionary<string, Func<byte[], byte[]>>();
+            CallCounts = new ConcurrentDictionary<string, int>();
+        }
+
+        public override Task DoAction(FlightAction request, IAsyncStreamWriter<FlightResult> responseStream, ServerCallContext context)
+        {
+            CallCounts.AddOrUpdate(request.Type, 1, (_, count) => count + 1);
+
+            if (!Handlers.TryGetValue(request.Type, out var handler))
+            {
+                throw new RpcException(new Status(StatusCode.Unimplemented, $"no handler registered for action {request.Type}"));
+            }
+
+            var responseBody = handler(request.Body.ToByteArray());
+            return responseStream.WriteAsync(new FlightResult(responseBody));
+        }
+    }
+}

--- a/SpiceTest/AsyncQueryTest.cs
+++ b/SpiceTest/AsyncQueryTest.cs
@@ -56,7 +56,7 @@ public class AsyncQueryTest
     // ==================== Submit + status ====================
 
     [Test]
-    public async Task Test_SubmitQueryAsync_ReturnsHandle_WithInitialStatus()
+    public async Task Test_QueryAsync_ReturnsHandle_WithInitialStatus()
     {
         await using var server = await AsyncQueryTestServer.StartAsync();
         server.On(AsyncQueryActions.Submit, _ => """{"query_id":"q-1","status":"PENDING"}""");
@@ -64,7 +64,7 @@ public class AsyncQueryTest
 
         using var client = server.BuildClient();
 
-        var query = await client.SubmitQueryAsync("SELECT 1");
+        var query = await client.QueryAsync("SELECT 1");
 
         Assert.That(query.Id, Is.EqualTo("q-1"));
         Assert.That(query.Status, Is.EqualTo(QueryStatus.Pending));
@@ -91,7 +91,7 @@ public class AsyncQueryTest
         });
 
         using var client = server.BuildClient();
-        var query = await client.SubmitQueryAsync("SELECT 1");
+        var query = await client.QueryAsync("SELECT 1");
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var status = await query.WaitAsync(cts.Token);
@@ -112,7 +112,7 @@ public class AsyncQueryTest
         server.On(AsyncQueryActions.GetResult, _ => throw new RpcException(new Status(StatusCode.NotFound, "no chunks for an empty result")));
 
         using var client = server.BuildClient();
-        var query = await client.SubmitQueryAsync("SELECT 1 WHERE false");
+        var query = await client.QueryAsync("SELECT 1 WHERE false");
 
         using var reader = await query.GetResultsAsync();
         var batch = await reader.ReadNextRecordBatchAsync();
@@ -132,7 +132,7 @@ public class AsyncQueryTest
         server.OnBytes(AsyncQueryActions.GetResult, _ => chunk);
 
         using var client = server.BuildClient();
-        var query = await client.SubmitQueryAsync("SELECT n FROM t");
+        var query = await client.QueryAsync("SELECT n FROM t");
 
         using var reader = await query.GetResultsAsync();
         var batch = await reader.ReadNextRecordBatchAsync();
@@ -154,7 +154,7 @@ public class AsyncQueryTest
             """{"query_id":"q-5","status":"FAILED","error":{"error_code":"QueryExecutionError","message":"boom"}}""");
 
         using var client = server.BuildClient();
-        var query = await client.SubmitQueryAsync("SELECT 1/0");
+        var query = await client.QueryAsync("SELECT 1/0");
 
         var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await query.GetResultsAsync());
         Assert.That(ex!.Message, Does.Contain("boom"));
@@ -170,7 +170,7 @@ public class AsyncQueryTest
         server.On(AsyncQueryActions.Cancel, _ => """{"query_id":"q-6","cancelled":true,"status":"CANCELLED"}""");
 
         using var client = server.BuildClient();
-        var query = await client.SubmitQueryAsync("SELECT 1");
+        var query = await client.QueryAsync("SELECT 1");
 
         await query.CancelAsync();
 
@@ -181,7 +181,7 @@ public class AsyncQueryTest
     // ==================== Parameters ====================
 
     [Test]
-    public async Task Test_SubmitQueryWithParamsAsync_PlacesSqlAndParametersInRequestBody()
+    public async Task Test_QueryWithParamsAsync_PlacesSqlAndParametersInRequestBody()
     {
         string? submittedBody = null;
 
@@ -193,7 +193,7 @@ public class AsyncQueryTest
         });
 
         using var client = server.BuildClient();
-        await client.SubmitQueryWithParamsAsync("SELECT * FROM t WHERE id = $1", 42);
+        await client.QueryWithParamsAsync("SELECT * FROM t WHERE id = $1", 42);
 
         Assert.That(submittedBody, Is.Not.Null);
         using var document = JsonDocument.Parse(submittedBody!);
@@ -205,7 +205,7 @@ public class AsyncQueryTest
     }
 
     [Test]
-    public async Task Test_SubmitQueryAsync_WithoutParams_OmitsParametersField()
+    public async Task Test_QueryAsync_WithoutParams_OmitsParametersField()
     {
         string? submittedBody = null;
 
@@ -217,7 +217,7 @@ public class AsyncQueryTest
         });
 
         using var client = server.BuildClient();
-        await client.SubmitQueryAsync("SELECT 1");
+        await client.QueryAsync("SELECT 1");
 
         using var document = JsonDocument.Parse(submittedBody!);
         Assert.That(document.RootElement.TryGetProperty("parameters", out _), Is.False);

--- a/SpiceTest/FlightQueryTest.cs
+++ b/SpiceTest/FlightQueryTest.cs
@@ -70,7 +70,7 @@ public class FlightQueryTest
     [Test]
     public async Task TestTpchQ1()
     {
-        var result = await _spiceClient.Query(
+        var result = await _spiceClient.SqlAsync(
             """
             SELECT
                 l_returnflag,
@@ -150,7 +150,7 @@ public class FlightQueryTest
     [Test]
     public async Task TestTpchQ2()
     {
-        var result = await _spiceClient.Query(
+        var result = await _spiceClient.SqlAsync(
             """
             SELECT
                 s.s_acctbal,
@@ -233,7 +233,7 @@ public class FlightQueryTest
     [Test]
     public async Task TestTpchQ3()
     {
-        var result = await _spiceClient.Query(
+        var result = await _spiceClient.SqlAsync(
             """
             SELECT
                 l_orderkey,
@@ -307,7 +307,7 @@ public class FlightQueryTest
     [Test]
     public async Task TestTpchQ4()
     {
-        var result = await _spiceClient.Query(
+        var result = await _spiceClient.SqlAsync(
             """
             SELECT
                 o_orderpriority,
@@ -373,7 +373,7 @@ public class FlightQueryTest
     [Test]
     public async Task TestTpchQ5()
     {
-        var result = await _spiceClient.Query(
+        var result = await _spiceClient.SqlAsync(
             """
             SELECT
                 n_name,
@@ -450,7 +450,7 @@ public class FlightQueryTest
     public async Task TestTpchQ6()
     {
         // TPC-H Q6: Forecasting Revenue Change Query
-        var result = await _spiceClient.Query(@"
+        var result = await _spiceClient.SqlAsync(@"
             SELECT SUM(l_extendedprice * l_discount) AS revenue
             FROM tpch.lineitem
             WHERE l_shipdate >= DATE '1994-01-01'
@@ -488,7 +488,7 @@ public class FlightQueryTest
     public async Task TestTpchQ7()
     {
         // TPC-H Q7: Volume Shipping Query
-        var result = await _spiceClient.Query(@"
+        var result = await _spiceClient.SqlAsync(@"
             SELECT supp_nation, cust_nation, l_year, SUM(volume) AS revenue
             FROM (
                 SELECT n1.n_name AS supp_nation,
@@ -554,7 +554,7 @@ public class FlightQueryTest
     public async Task TestTpchQ8()
     {
         // TPC-H Q8: National Market Share Query
-        var result = await _spiceClient.Query(@"
+        var result = await _spiceClient.SqlAsync(@"
             SELECT o_year,
                    SUM(CASE WHEN nation = 'BRAZIL' THEN volume ELSE 0 END) / SUM(volume) AS mkt_share
             FROM (
@@ -613,7 +613,7 @@ public class FlightQueryTest
     public async Task TestTpchQ9()
     {
         // TPC-H Q9: Product Type Profit Measure Query
-        var result = await _spiceClient.Query(@"
+        var result = await _spiceClient.SqlAsync(@"
             SELECT nation, o_year, SUM(amount) AS sum_profit
             FROM (
                 SELECT n_name AS nation,
@@ -681,7 +681,7 @@ public class FlightQueryTest
     public async Task TestTpchQ10()
     {
         // TPC-H Q10: Returned Item Reporting Query
-        var result = await _spiceClient.Query(@"
+        var result = await _spiceClient.SqlAsync(@"
             SELECT c_custkey, c_name, SUM(l_extendedprice * (1 - l_discount)) AS revenue,
                    c_acctbal, n_name, c_address, c_phone, c_comment
             FROM tpch.customer, tpch.orders, tpch.lineitem, tpch.nation

--- a/SpiceTest/ParameterizedQueryIntegrationTest.cs
+++ b/SpiceTest/ParameterizedQueryIntegrationTest.cs
@@ -91,7 +91,7 @@ public class ParameterizedQueryIntegrationTest
     {
         try
         {
-            return await _spiceClient.QueryWithParams(sql, parameters);
+            return await _spiceClient.SqlWithParamsAsync(sql, parameters);
         }
         catch (AdbcException ex) when (ex.Message.Contains(PrepareNotSupportedMessage))
         {

--- a/SpiceTest/QueryStatusTest.cs
+++ b/SpiceTest/QueryStatusTest.cs
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+using Spice.Query;
+
+namespace SpiceTest;
+
+/// <summary>
+/// Unit tests for <see cref="QueryStatus"/>: terminal classification and the runtime's
+/// uppercase wire representation.
+/// </summary>
+[TestFixture]
+public class QueryStatusTest
+{
+    [TestCase(QueryStatus.Pending, false)]
+    [TestCase(QueryStatus.Running, false)]
+    [TestCase(QueryStatus.Succeeded, true)]
+    [TestCase(QueryStatus.Failed, true)]
+    [TestCase(QueryStatus.Cancelled, true)]
+    [TestCase(QueryStatus.Closed, true)]
+    public void Test_IsTerminal_ClassifiesEveryStatus(QueryStatus status, bool expected)
+    {
+        Assert.That(status.IsTerminal(), Is.EqualTo(expected));
+    }
+
+    [TestCase(QueryStatus.Pending, "\"PENDING\"")]
+    [TestCase(QueryStatus.Running, "\"RUNNING\"")]
+    [TestCase(QueryStatus.Succeeded, "\"SUCCEEDED\"")]
+    [TestCase(QueryStatus.Failed, "\"FAILED\"")]
+    [TestCase(QueryStatus.Cancelled, "\"CANCELLED\"")]
+    [TestCase(QueryStatus.Closed, "\"CLOSED\"")]
+    public void Test_SerializesToRuntimeUppercaseWireValue(QueryStatus status, string expectedJson)
+    {
+        Assert.That(JsonSerializer.Serialize(status), Is.EqualTo(expectedJson));
+    }
+
+    [TestCase("\"PENDING\"", QueryStatus.Pending)]
+    [TestCase("\"RUNNING\"", QueryStatus.Running)]
+    [TestCase("\"SUCCEEDED\"", QueryStatus.Succeeded)]
+    [TestCase("\"FAILED\"", QueryStatus.Failed)]
+    [TestCase("\"CANCELLED\"", QueryStatus.Cancelled)]
+    [TestCase("\"CLOSED\"", QueryStatus.Closed)]
+    public void Test_DeserializesRuntimeUppercaseWireValue(string json, QueryStatus expected)
+    {
+        Assert.That(JsonSerializer.Deserialize<QueryStatus>(json), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Test_DeserializingUnrecognizedValue_Throws()
+    {
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<QueryStatus>("\"NOT_A_STATUS\""));
+    }
+}

--- a/SpiceTest/SpiceClientParamQueryTest.cs
+++ b/SpiceTest/SpiceClientParamQueryTest.cs
@@ -61,7 +61,7 @@ public class SpiceClientParamQueryTest
         
         Assert.ThrowsAsync<ObjectDisposedException>(async () =>
         {
-            await client.QueryWithParams("SELECT 1");
+            await client.SqlWithParamsAsync("SELECT 1");
         });
     }
 
@@ -243,7 +243,7 @@ public class SpiceClientParamQueryTest
         // After using block, client should be disposed
         Assert.ThrowsAsync<ObjectDisposedException>(async () =>
         {
-            await clientRef!.Query("SELECT 1");
+            await clientRef!.SqlAsync("SELECT 1");
         });
     }
 }

--- a/SpiceTest/SpiceTest.csproj
+++ b/SpiceTest/SpiceTest.csproj
@@ -6,8 +6,16 @@
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>
 
+    <!-- Used only to host an in-process Flight server (Apache.Arrow.Flight.AspNetCore) for
+         async-query tests; the shipped Spice package has no ASP.NET Core dependency. -->
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
     <ItemGroup>
         <PackageReference Include="Apache.Arrow.Adbc.Drivers.Interop.FlightSql" Version="0.21.0" />
+        <PackageReference Include="Apache.Arrow.Flight.AspNetCore" Version="22.1.0" />
+        <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="NUnit" Version="3.14.0"/>


### PR DESCRIPTION
## Summary
- **Breaking change**, matching the same change already made in the gospice and spice-rs SDKs: `Query` / `QueryWithParams` now submit a query for **asynchronous** execution over Flight `DoAction` and return an `AsyncQuery` handle (poll status, fetch results as an Arrow stream, cancel). Requires the runtime to be running in distributed/scheduler mode.
- The previous **synchronous, streaming** behavior of `Query` / `QueryWithParams` is preserved under new names: `SqlAsync` / `SqlWithParamsAsync`.
- Updated README and all call sites (tests) to the new names.

## Test plan
- [x] `dotnet build` succeeds for netstandard2.0, net8.0, net9.0 (net10.0 SDK unavailable locally; unaffected by this change)
- [x] `dotnet test` passes on net9.0 — 199 passed, 33 skipped (env-gated), 0 failed