### PR TITLE
docs: update v0.4.0 release notes for active queries and async queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,36 @@ matched column values in `Matches`, the row's `PrimaryKey`, the columns requeste
 `AdditionalColumns` in `Data`, and any `Metadata`. The runtime omits the last three when
 empty; they default to empty dictionaries, so they can be read without a null check.
 
+#### Active Query Management
+
+`ListActiveQueriesAsync` reports the synchronous queries currently running on the runtime,
+and `CancelActiveQueryAsync` cancels one by ID. The runtime doesn't hand a query's ID back
+to the client that submitted it, so listing is the only way to find the ID that cancelling
+needs.
+
+```csharp
+using Spice;
+using Spice.Query;
+
+using var client = new SpiceClientBuilder().Build();
+
+var queries = await client.ListActiveQueriesAsync();
+foreach (var query in queries)
+{
+    Console.WriteLine($"{query.QueryId} {query.Protocol} {query.SqlPreview}");
+}
+
+if (queries.Count > 0)
+{
+    await client.CancelActiveQueryAsync(queries[0].QueryId);
+}
+```
+
+Both calls are scoped to the authenticated API key or client certificate — not to this
+`SpiceClient` instance — and reach only the one runtime process behind this client's HTTP
+endpoint. Runtime releases up to and including v2.1.5 do not scope either endpoint at all —
+every caller sees and can cancel every query regardless of credential.
+
 #### Async Queries
 
 `QueryAsync` submits a query for asynchronous execution over Flight and returns an

--- a/docs/release_notes/v0.4.0.md
+++ b/docs/release_notes/v0.4.0.md
@@ -85,6 +85,19 @@ using var client = new SpiceClientBuilder()
 
 `WithTlsClientCertificate` implies `WithTls(true)`. Applies to both the Flight (gRPC) and HTTP clients.
 
+### Async Queries
+
+`SpiceClient.QueryAsync(string, CancellationToken)` submits a query for asynchronous execution over Flight and returns an `AsyncQuery` handle for polling status and fetching results, instead of streaming results directly. This requires the runtime to be running in distributed/scheduler mode. `QueryWithParamsAsync` submits a parameterized query the same way, binding `$1`, `$2`, etc. positionally.
+
+```csharp
+var query = await client.QueryAsync("SELECT * FROM taxi_trips");
+await query.WaitAsync();
+
+using var results = await query.GetResultsAsync();
+```
+
+An `AsyncQuery` also exposes `GetStatusAsync` for a single status poll and `CancelAsync` to request cancellation.
+
 ### Active Query Management
 
 New `SpiceClient.ListActiveQueriesAsync()` reports the synchronous queries currently running on the runtime, and `CancelActiveQueryAsync(queryId)` cancels one. The runtime doesn't hand a query's ID back to the client that submitted it, so listing is the only way to find the ID that cancelling needs.
@@ -103,21 +116,6 @@ if (queries.Count > 0)
     await client.CancelActiveQueryAsync(queries[0].QueryId);
 }
 ```
-
-Both calls are scoped to the authenticated API key or client certificate, not to the `SpiceClient` instance, and reach only the one runtime process behind this client's HTTP endpoint. Runtime releases up to and including v2.1.5 do not scope either endpoint at all — every caller sees and can cancel every query regardless of credential.
-
-### Async Queries
-
-`SpiceClient.QueryAsync(string, CancellationToken)` submits a query for asynchronous execution over Flight and returns an `AsyncQuery` handle for polling status and fetching results, instead of streaming results directly. This requires the runtime to be running in distributed/scheduler mode. `QueryWithParamsAsync` submits a parameterized query the same way, binding `$1`, `$2`, etc. positionally.
-
-```csharp
-var query = await client.QueryAsync("SELECT * FROM taxi_trips");
-await query.WaitAsync();
-
-using var results = await query.GetResultsAsync();
-```
-
-An `AsyncQuery` also exposes `GetStatusAsync` for a single status poll and `CancelAsync` to request cancellation.
 
 ## Bug Fixes
 

--- a/docs/release_notes/v0.4.0.md
+++ b/docs/release_notes/v0.4.0.md
@@ -85,6 +85,40 @@ using var client = new SpiceClientBuilder()
 
 `WithTlsClientCertificate` implies `WithTls(true)`. Applies to both the Flight (gRPC) and HTTP clients.
 
+### Active Query Management
+
+New `SpiceClient.ListActiveQueriesAsync()` reports the synchronous queries currently running on the runtime, and `CancelActiveQueryAsync(queryId)` cancels one. The runtime doesn't hand a query's ID back to the client that submitted it, so listing is the only way to find the ID that cancelling needs.
+
+```csharp
+using Spice.Query;
+
+var queries = await client.ListActiveQueriesAsync();
+foreach (var query in queries)
+{
+    Console.WriteLine($"{query.QueryId} {query.Protocol} {query.SqlPreview}");
+}
+
+if (queries.Count > 0)
+{
+    await client.CancelActiveQueryAsync(queries[0].QueryId);
+}
+```
+
+Both calls are scoped to the authenticated API key or client certificate, not to the `SpiceClient` instance, and reach only the one runtime process behind this client's HTTP endpoint. Runtime releases up to and including v2.1.5 do not scope either endpoint at all — every caller sees and can cancel every query regardless of credential.
+
+### Async Queries
+
+`SpiceClient.QueryAsync(string, CancellationToken)` submits a query for asynchronous execution over Flight and returns an `AsyncQuery` handle for polling status and fetching results, instead of streaming results directly. This requires the runtime to be running in distributed/scheduler mode. `QueryWithParamsAsync` submits a parameterized query the same way, binding `$1`, `$2`, etc. positionally.
+
+```csharp
+var query = await client.QueryAsync("SELECT * FROM taxi_trips");
+await query.WaitAsync();
+
+using var results = await query.GetResultsAsync();
+```
+
+An `AsyncQuery` also exposes `GetStatusAsync` for a single status poll and `CancelAsync` to request cancellation.
+
 ## Bug Fixes
 
 - Fixed `AuthenticateAsync` throwing `System.InvalidOperationException: Can't get the call trailers because the call has not completed successfully` on a failed handshake, which masked the actual gRPC authentication error. The auth token is now read from response headers first, falling back to trailers only when headers carry none.
@@ -98,4 +132,14 @@ Added:
 
 ## Breaking Changes
 
-None.
+**`Query` and `QueryWithParams` now submit SQL for asynchronous execution and return an `AsyncQuery` handle**, instead of streaming results directly. The previous synchronous, streaming behavior is now `SqlAsync`/`SqlWithParamsAsync`:
+
+```csharp
+// Before (v0.3.0 and earlier)
+using var stream = await client.Query("SELECT * FROM taxi_trips");
+
+// After (v0.4.0)
+using var stream = await client.SqlAsync("SELECT * FROM taxi_trips");
+```
+
+Async queries additionally require the runtime to be running in distributed/scheduler mode; calling `Query`/`QueryWithParams` against a single-node runtime now returns an error explaining that, rather than the query results.


### PR DESCRIPTION
## Summary
- Adds an **Active Query Management** section to the v0.4.0 release notes (#26, merged) — and to the README, which never got one: #26 shipped `ListActiveQueriesAsync`/`CancelActiveQueryAsync` without adding README docs, unlike #27's async-queries section.
- Adds an **Async Queries** section to the release notes (#27, merged).
- Replaces the release notes' "Breaking Changes: None" with the actual breaking change #27 introduced: `Query`/`QueryWithParams` now submit for asynchronous execution and return an `AsyncQuery` handle; the old synchronous, streaming behavior moved to `SqlAsync`/`SqlWithParamsAsync`.

Docs-only change; no code changes.